### PR TITLE
LRQA-45894 - JDK 11 modules integration tests

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4118,6 +4118,24 @@ log.sanitizer.enabled=false</echo>
 		/>
 	</target>
 
+	<target name="modules-integration-bundle-db2111-jdk11_open">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="db2"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
 	<target name="modules-integration-bundle-hypersonic20-jdk8">
 		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
 
@@ -4136,7 +4154,43 @@ log.sanitizer.enabled=false</echo>
 		/>
 	</target>
 
+	<target name="modules-integration-bundle-hypersonic20-jdk11_open">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="hypersonic"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
 	<target name="modules-integration-bundle-mariadb102-jdk8">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="mariadb"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
+	<target name="modules-integration-bundle-mariadb102-jdk11_open">
 		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
 
 		<run-modules-integration-test
@@ -4173,7 +4227,44 @@ log.sanitizer.enabled=false</echo>
 		/>
 	</target>
 
+	<target name="modules-integration-bundle-mysql57-jdk11_open">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="mysql"
+			database.version="5.7"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
 	<target name="modules-integration-bundle-oracle122-jdk8">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="oracle"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
+	<target name="modules-integration-bundle-oracle122-jdk11_open">
 		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
 
 		<run-modules-integration-test
@@ -4209,7 +4300,43 @@ log.sanitizer.enabled=false</echo>
 		/>
 	</target>
 
+	<target name="modules-integration-bundle-postgresql10-jdk11_open">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="postgresql"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
 	<target name="modules-integration-bundle-sybase160-jdk8">
+		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
+
+		<run-modules-integration-test
+			database.type="sybase"
+			test.build.fix.pack.zip.url="${test.build.fix.pack.zip.url}"
+			test.fix.pack.base.url="${test.fix.pack.base.url}"
+			test.license.xml.url="${test.license.xml.url}"
+			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
+			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
+			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
+			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
+			test.sql.zip.url="${test.sql.zip.url}"
+		/>
+	</target>
+
+	<target name="modules-integration-bundle-sybase160-jdk11_open">
 		<set-tomcat-version-number liferay.portal.bundle="${test.portal.bundle.version}" />
 
 		<run-modules-integration-test
@@ -4231,11 +4358,23 @@ log.sanitizer.enabled=false</echo>
 		<run-modules-integration-test database.type="db2" />
 	</target>
 
+	<target name="modules-integration-db2111-jdk11_open">
+		<run-modules-integration-test database.type="db2" />
+	</target>
+
 	<target name="modules-integration-hypersonic20-jdk8">
 		<run-modules-integration-test database.type="hypersonic" />
 	</target>
 
+	<target name="modules-integration-hypersonic20-jdk11_open">
+		<run-modules-integration-test database.type="hypersonic" />
+	</target>
+
 	<target name="modules-integration-mariadb102-jdk8">
+		<run-modules-integration-test database.type="mariadb" />
+	</target>
+
+	<target name="modules-integration-mariadb102-jdk11_open">
 		<run-modules-integration-test database.type="mariadb" />
 	</target>
 
@@ -4247,7 +4386,15 @@ log.sanitizer.enabled=false</echo>
 		<run-modules-integration-test database.type="mysql" database.version="5.7" />
 	</target>
 
+	<target name="modules-integration-mysql57-jdk11_open">
+		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+	</target>
+
 	<target name="modules-integration-oracle122-jdk8">
+		<run-modules-integration-test database.type="oracle" />
+	</target>
+
+	<target name="modules-integration-oracle122-jdk11_open">
 		<run-modules-integration-test database.type="oracle" />
 	</target>
 
@@ -4255,7 +4402,15 @@ log.sanitizer.enabled=false</echo>
 		<run-modules-integration-test database.type="postgresql" />
 	</target>
 
+	<target name="modules-integration-postgresql10-jdk11_open">
+		<run-modules-integration-test database.type="postgresql" />
+	</target>
+
 	<target name="modules-integration-sybase160-jdk8">
+		<run-modules-integration-test database.type="sybase" />
+	</target>
+
+	<target name="modules-integration-sybase160-jdk11_open">
 		<run-modules-integration-test database.type="sybase" />
 	</target>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2200,6 +2200,7 @@ log.sanitizer.enabled=false</echo>
 		<attribute default="" name="test.portal.bundle.dependencies.zip.url" />
 		<attribute default="" name="test.portal.bundle.osgi.zip.url" />
 		<attribute default="" name="test.portal.bundle.tools.zip.url" />
+		<attribute default="" name="test.portal.bundle.version" />
 		<attribute default="" name="test.portal.bundle.war.url" />
 		<attribute default="" name="test.portal.bundle.zip.url" />
 		<attribute default="" name="test.sql.zip.url" />
@@ -2223,7 +2224,7 @@ log.sanitizer.enabled=false</echo>
 
 							<echo>Executing Gradle task in directory "modules": testIntegration.</echo>
 
-							<setup-test-batch-testable-tomcat />
+							<setup-test-batch-testable-tomcat test.portal.bundle.version="@{test.portal.bundle.version}" />
 
 							<antcall target="start-app-server-preserve-liferay-home" />
 
@@ -4110,6 +4111,7 @@ log.sanitizer.enabled=false</echo>
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"
@@ -4127,6 +4129,7 @@ log.sanitizer.enabled=false</echo>
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"
@@ -4144,6 +4147,7 @@ log.sanitizer.enabled=false</echo>
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"
@@ -4161,6 +4165,7 @@ log.sanitizer.enabled=false</echo>
 			test.license.xml.url="${test.license.xml.url}"
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
@@ -4179,6 +4184,7 @@ log.sanitizer.enabled=false</echo>
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"
@@ -4196,6 +4202,7 @@ log.sanitizer.enabled=false</echo>
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"
@@ -4213,6 +4220,7 @@ log.sanitizer.enabled=false</echo>
 			test.portal.bundle.dependencies.zip.url="${test.portal.bundle.dependencies.zip.url}"
 			test.portal.bundle.osgi.zip.url="${test.portal.bundle.osgi.zip.url}"
 			test.portal.bundle.tools.zip.url="${test.portal.bundle.tools.zip.url}"
+			test.portal.bundle.version="${test.portal.bundle.version}"
 			test.portal.bundle.war.url="${test.portal.bundle.war.url}"
 			test.portal.bundle.zip.url="${test.portal.bundle.zip.url}"
 			test.sql.zip.url="${test.sql.zip.url}"

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2219,19 +2219,21 @@ log.sanitizer.enabled=false</echo>
 
 							<antcall inheritAll="false" target="prepare-system-ext-properties" />
 
-							<get-test-batch-app-server-start-executable-arg-line />
-
 							<print-test-class-group test.class.group.index="${axis.variable}" />
 
 							<echo>Executing Gradle task in directory "modules": testIntegration.</echo>
 
+							<setup-test-batch-testable-tomcat />
+
+							<antcall target="start-app-server-preserve-liferay-home" />
+
 							<gradle-execute dir="modules" refreshdependencies="@{refreshdependencies}" task="testIntegration">
 								<arg value="--continue" />
-								<arg value="-Dapp.server.start.executable.arg.line=${test.batch.app.server.start.executable.arg.line}" />
-								<arg value="-Ddatabase.type=@{database.type}" />
 								<arg value="-Dbuild.exclude.ant.plugin=true" />
 								<arg value="-Dtest.class.group.index=${axis.variable}" />
 							</gradle-execute>
+
+							<antcall target="stop-app-server" />
 
 							<if>
 								<and>

--- a/test.properties
+++ b/test.properties
@@ -1198,6 +1198,7 @@
         modules-integration-hypersonic20-jdk8,\
         modules-integration-mariadb102-jdk8,\
         modules-integration-mysql57-jdk8,\
+        modules-integration-mysql57-jdk11_open,\
         modules-integration-oracle122-jdk8,\
         modules-integration-postgresql10-jdk8,\
         #modules-integration-sybase160-jdk8,\

--- a/test.properties
+++ b/test.properties
@@ -1020,6 +1020,7 @@
     test.batch.axis.max.size[integration-*-jdk11_open]=5000
     test.batch.axis.max.size[modules-compile-jdk8]=500
     test.batch.axis.max.size[modules-integration-*-jdk8]=35
+    test.batch.axis.max.size[modules-integration-*-jdk11_open]=35
     test.batch.axis.max.size[modules-semantic-versioning-jdk8]=30
     test.batch.axis.max.size[modules-unit-jdk8]=250
     test.batch.axis.max.size[modules-unit-project-templates-jdk8]=250
@@ -1066,6 +1067,7 @@
     test.batch.class.names.includes[integration-*-jdk11_open]=**/test/integration/**/*Test.java
     test.batch.class.names.includes[junit-test-csv-report-jdk8]=${test.batch.class.names.includes}
     test.batch.class.names.includes[modules-integration-*-jdk8]=**/src/testIntegration/**/*Test.java
+    test.batch.class.names.includes[modules-integration-*-jdk11_open]=**/src/testIntegration/**/*Test.java
     test.batch.class.names.includes[modules-unit-jdk8]=**/src/test/**/*Test.java
     test.batch.class.names.includes[modules-unit-project-templates-jdk8]=**/project-templates/**/src/test/**/*Test.java
 
@@ -1073,6 +1075,10 @@
     test.batch.class.names.includes[unit-jdk8]=**/test/unit/**/*Test.java
 
     test.batch.class.names.includes.required[modules-integration-*-jdk8]=\
+        **/src/testIntegration/**/DeclarativeServiceDependencyManagerTest.java,\
+        **/src/testIntegration/**/SpringExtenderDependencyManagerTest.java
+
+    test.batch.class.names.includes.required[modules-integration-*-jdk11_open]=\
         **/src/testIntegration/**/DeclarativeServiceDependencyManagerTest.java,\
         **/src/testIntegration/**/SpringExtenderDependencyManagerTest.java
 

--- a/test.properties
+++ b/test.properties
@@ -1728,7 +1728,14 @@
         integration-mysql57-jdk11_open,\
         integration-oracle122-jdk11_open,\
         integration-postgresql10-jdk11_open,\
-        integration-sybase160-jdk11_open
+        integration-sybase160-jdk11_open,\
+        modules-integration-db2111-jdk11_open,\
+        modules-integration-hypersonic20-jdk11_open,\
+        modules-integration-mariadb102-jdk11_open,\
+        modules-integration-mysql57-jdk11_open,\
+        modules-integration-oracle122-jdk11_open,\
+        modules-integration-postgresql10-jdk11_open,\
+        modules-integration-sybase160-jdk11_open
 
     #
     # JSF

--- a/test.properties
+++ b/test.properties
@@ -1721,7 +1721,7 @@
         functional-upgrade-tomcat90-mysql57-jdk11_open,\
         functional-upgrade-tomcat90-oracle122-jdk11_open,\
         functional-upgrade-tomcat90-postgresql10-jdk11_open,\
-        functional-upgrade-tomcat90-sybase160-jdk11_open,\
+        #functional-upgrade-tomcat90-sybase160-jdk11_open,\
         functional-upgrade-wildfly110-mariadb102-jdk11_open,\
         integration-db2111-jdk11_open,\
         integration-hypersonic20-jdk11_open,\
@@ -1729,14 +1729,14 @@
         integration-mysql57-jdk11_open,\
         integration-oracle122-jdk11_open,\
         integration-postgresql10-jdk11_open,\
-        integration-sybase160-jdk11_open,\
+        #integration-sybase160-jdk11_open,\
         modules-integration-db2111-jdk11_open,\
         modules-integration-hypersonic20-jdk11_open,\
         modules-integration-mariadb102-jdk11_open,\
         modules-integration-mysql57-jdk11_open,\
         modules-integration-oracle122-jdk11_open,\
         modules-integration-postgresql10-jdk11_open,\
-        modules-integration-sybase160-jdk11_open
+        #modules-integration-sybase160-jdk11_open
 
     #
     # JSF


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-45894

this is complete on the QA end for java 11 modules integration tests. all that's left is to run them and see if there are any diffs between java 8 modules integration and java 11 modules integration and fix them before merging to ensure parity.