### PR TITLE
LPS-X Java 11 compile

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -238,7 +238,7 @@
 		</or>
 	</condition>
 
-	<fail message="Please use Java 1.8.">
+	<!-- <fail message="Please use Java 1.8.">
 		<condition>
 			<not>
 				<or>
@@ -247,7 +247,7 @@
 				</or>
 			</not>
 		</condition>
-	</fail>
+	</fail> -->
 
 	<condition property="correct.ant.version">
 		<antversion atleast="1.9.3" />

--- a/gradlew
+++ b/gradlew
@@ -88,6 +88,8 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
 fi
 
+export JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS} --add-exports=java.compiler/javax.tools=ALL-UNNAMED"
+
 # Increase the maximum file descriptors if we can.
 if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`

--- a/lib/development/dependencies.properties
+++ b/lib/development/dependencies.properties
@@ -1,6 +1,6 @@
 activation=javax.activation:activation:1.1
 alloy-taglib=com.liferay.alloy-taglibs:alloy-taglib:1.1.13
-annotations=javax.annotation:jsr250-api:1.0
+annotations=javax.annotation:javax.annotation-api:1.3
 ant-apache-bsf=org.apache.ant:ant-apache-bsf:1.8.2
 appium=io.appium:java-client:1.6.2
 catalina=org.apache.tomcat:tomcat-catalina:9.0.17

--- a/modules/apps/bulk/bulk-rest-api/build.gradle
+++ b/modules/apps/bulk/bulk-rest-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/bulk/bulk-rest-api/build.gradle
+++ b/modules/apps/bulk/bulk-rest-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/bulk/bulk-rest-client/build.gradle
+++ b/modules/apps/bulk/bulk-rest-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/bulk/bulk-rest-impl/build.gradle
+++ b/modules/apps/bulk/bulk-rest-impl/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"

--- a/modules/apps/bulk/bulk-rest-test/build.gradle
+++ b/modules/apps/bulk/bulk-rest-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:bulk:bulk-rest-api")
 	testIntegrationCompile project(":apps:bulk:bulk-rest-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/change-tracking/change-tracking-rest/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-rest/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"

--- a/modules/apps/data-engine/data-engine-rest-api/build.gradle
+++ b/modules/apps/data-engine/data-engine-rest-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/data-engine/data-engine-rest-api/build.gradle
+++ b/modules/apps/data-engine/data-engine-rest-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/data-engine/data-engine-rest-client/build.gradle
+++ b/modules/apps/data-engine/data-engine-rest-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/build.gradle
+++ b/modules/apps/data-engine/data-engine-rest-impl/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"

--- a/modules/apps/data-engine/data-engine-rest-test/build.gradle
+++ b/modules/apps/data-engine/data-engine-rest-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationCompile project(":apps:data-engine:data-engine-rest-client")
 	testIntegrationCompile project(":apps:dynamic-data-lists:dynamic-data-lists-api")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "commons-collections", name: "commons-collections", version: "3.2.2"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
 	testIntegrationCompile project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "commons-collections", name: "commons-collections", version: "3.2.2"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	testIntegrationCompile project(":apps:headless:headless-admin-user:headless-admin-user-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:headless:headless-admin-workflow:headless-admin-workflow-api")
 	testIntegrationCompile project(":apps:headless:headless-admin-workflow:headless-admin-workflow-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:blogs:blogs-api")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")

--- a/modules/apps/headless/headless-form/headless-form-api/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-form/headless-form-api/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/headless/headless-form/headless-form-client/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-client/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 }

--- a/modules/apps/headless/headless-form/headless-form-impl/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-impl/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"

--- a/modules/apps/headless/headless-form/headless-form-test/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 	testIntegrationCompile project(":apps:headless:headless-form:headless-form-api")
 	testIntegrationCompile project(":apps:headless:headless-form:headless-form-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/portal-remote/portal-remote-jaxrs-security-impl/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-jaxrs-security-impl/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"

--- a/modules/apps/portal-remote/portal-remote-soap-extender-impl/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-impl/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileInclude group: "org.apache.cxf", name: "cxf-rt-ws-policy", version: "3.2.5"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay", name: "javax.xml.ws", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.2.5"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "3.2.0"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	compileOnly group: "com.fasterxml.jackson.jaxrs", name: "jackson-jaxrs-json-provider", version: "2.9.8"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/build.gradle
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"

--- a/modules/apps/websocket/websocket-whiteboard-test/build.gradle
+++ b/modules/apps/websocket/websocket-whiteboard-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay", name: "javax.xml.bind", version: "2.3.0.LIFERAY-PATCHED-1"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel",version: "default"
 	testIntegrationCompile group: "javax.websocket", name: "javax.websocket-api", version: "1.1"
 	testIntegrationCompile group: "junit", name: "junit", version: "4.12"

--- a/modules/core/jaxws-osgi-bridge/build.gradle
+++ b/modules/core/jaxws-osgi-bridge/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileOnly group: "javax.xml.ws", name: "jaxws-api", version: "2.3.1"
+	compileOnly group: "com.liferay", name: "javax.xml.ws", version: "2.3.0.LIFERAY-PATCHED-1"
 	compileOnly project(":core:registry-api")
 }
 

--- a/modules/third-party/javax-xml-ws/build.gradle
+++ b/modules/third-party/javax-xml-ws/build.gradle
@@ -1,7 +1,7 @@
 task jarPatched(type: Zip)
 
 dependencies {
-	compileOnly group: "javax.xml.ws", name: "jaxws-api", transitive: false, version: "2.3.0"
+	compileOnly group: "com.liferay", name: "javax.xml.ws", transitive: false, version: "2.3.0.LIFERAY-PATCHED-1"
 }
 
 jar {


### PR DESCRIPTION
I don't currently have a ticket for this at the moment, since java 11 compile wasn't on the 7.2 roadmap. may need one ticket for the entire java 11 compile or multiple tickets to get each module to be java-11 compile compatible.

with the `generateJspJava`, I wasn't able to get any further. that's where my java 11 compile work was blocked.