### PR TITLE
LRQA-54910 | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -8936,11 +8936,7 @@ portal.security.manager.strategy=liferay</echo>
 		</if>
 
 		<if>
-			<or>
-				<equals arg1="${app.server.type}" arg2="weblogic" />
-				<equals arg1="${app.server.type}" arg2="websphere" />
-				<equals arg1="${javascript.fast.load}" arg2="false" />
-			</or>
+			<equals arg1="${javascript.fast.load}" arg2="false" />
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 


### PR DESCRIPTION
**Description**
The flaky issue between js.fast.load and slow test environments seems to have been fixed sometime between last year and now. This aims to re-enable js.fast.load on weblogic and websphere since they now seem stable [8 out of 8 passed](https://github.com/john-co/liferay-portal/pull/367).

**Test Plan**
Run smoke tests on weblogic and websphere, make sure they pass consistently.

**Jira Ticket**
https://issues.liferay.com/browse/LRQA-54910