### PR TITLE
master LRQA 69313 2

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/OSGiConfig.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/OSGiConfig.macro
@@ -1,6 +1,6 @@
 definition {
 
-	macro deployOSGiConfigFile {
+	macro copyOSGiConfigFile {
 		Variables.assertDefined(parameterList = "${OSGiConfigFileBaseDir},${OSGiConfigFileName}");
 
 		var configs = FileUtil.read("${OSGiConfigFileBaseDir}/${OSGiConfigFileName}");
@@ -10,7 +10,7 @@ definition {
 		FileUtil.write("${liferayHome}/osgi/configs/${OSGiConfigFileName}", "${configs}");
 	}
 
-	macro deployOSGiConfigs {
+	macro deployOSGiConfigFile {
 		Variables.assertDefined(parameterList = "${OSGiConfigs},${OSGiConfigFileName}");
 
 		var configList = "";

--- a/portal-web/test/functional/com/liferay/portalweb/macros/OpenIDConnect.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/OpenIDConnect.macro
@@ -73,6 +73,10 @@ definition {
 			fieldName = "discoveryEndPoint",
 			fieldValue = "https://accounts.google.com/.well-known/openid-configuration");
 
+		FormFields.editTextMultiline(
+			fieldName = "registeredIdTokenSigningAlg",
+			fieldValue = "RS256");
+
 		PortletEntry.save();
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -881,13 +881,7 @@ definition {
 			OSGiConfigFileBaseDir = "${tempFileDirectory}",
 			OSGiConfigFileName = "${tempFileName}");
 
-		Portlet.shutdownServer();
-
-		Portlet.startServer();
-
-		Navigator.openSpecificURL(url = "${portalURL}/c/portal/logout");
-
-		User.firstLoginPG();
+		Pause(locator = "20000");
 
 		PortalSettings.gotoConfiguration(
 			configurationCategory = "SSO",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -877,7 +877,7 @@ definition {
 
 		var tempFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration_*.config");
 
-		OSGiConfig.deployOSGiConfigFile(
+		OSGiConfig.copyOSGiConfigFile(
 			OSGiConfigFileBaseDir = "${tempFileDirectory}",
 			OSGiConfigFileName = "${tempFileName}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -841,10 +841,9 @@ definition {
 			userScreenName = "usersn");
 	}
 
-	@ignore = "true"
 	@priority = "4"
 	test ExportedFactoryConfigurationCanBeImported {
-		property portal.acceptance = "sharry";
+		property portal.acceptance = "true";
 
 		var openIDConnectClientID = PropsUtil.get("google.client.id.1");
 		var openIDConnectClientSecret = PropsUtil.get("google.client.secret.1");
@@ -876,7 +875,7 @@ definition {
 			fail("FAIL! Cannot find the configuration file exported from edit page for single factory.");
 		}
 
-		var tempFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration~*.config");
+		var tempFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration_*.config");
 
 		OSGiConfig.deployOSGiConfigFile(
 			OSGiConfigFileBaseDir = "${tempFileDirectory}",
@@ -1077,7 +1076,6 @@ definition {
 		}
 	}
 
-	@ignore = "true"
 	@priority = "4"
 	test SingleFactoryConfigurationCanBeExported {
 		var openIDConnectClientID = PropsUtil.get("google.client.id.1");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -881,12 +881,20 @@ definition {
 			OSGiConfigFileBaseDir = "${tempFileDirectory}",
 			OSGiConfigFileName = "${tempFileName}");
 
-		Pause(locator = "20000");
+		Pause(locator = "60000");
 
 		PortalSettings.gotoConfiguration(
 			configurationCategory = "SSO",
 			configurationName = "OpenID Connect Provider",
 			configurationScope = "Virtual Instance Scope");
+
+		while (IsElementNotPresent(locator1 = "ContentRow#ENTRY_CONTENT_ENTRY_NAME", key_rowEntry = "Google")) {
+			Pause(locator1 = "1000");
+
+			Refresh();
+
+			echo("Refreshed Page");
+		}
 
 		LexiconEntry.viewEntryName(rowEntry = "Google");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -145,7 +145,7 @@ definition {
 			entryComment = "WC WebContent Content Comment",
 			userFullName = "Test Test (You)");
 
-		OSGiConfig.deployOSGiConfigs(
+		OSGiConfig.deployOSGiConfigFile(
 			OSGiConfigFileName = "com.liferay.journal.configuration.JournalServiceConfiguration.config",
 			OSGiConfigs = "articleCommentsEnabled=B&quot;false&quot;");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/bundleblacklist/BundleBlacklist.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/bundleblacklist/BundleBlacklist.testcase
@@ -191,7 +191,7 @@ definition {
 
 		var tempFileDirectory = selenium.getOutputDirName();
 
-		OSGiConfig.deployOSGiConfigFile(
+		OSGiConfig.copyOSGiConfigFile(
 			OSGiConfigFileBaseDir = "${tempFileDirectory}",
 			OSGiConfigFileName = "com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config");
 


### PR DESCRIPTION
- LRQA-69313 Enable factory config tests
- LRQA-69313 Server restart not needed since configs can deploy during runtime
- LRQA-69313 Rename config macros
- LRQA-69313 Test stability since the UI not immediately rendering the imported config in every case
- LRQA-69313 Add configuration to cancel warning from appearing in portal logs
