### PR TITLE
LPS-153766 Add commons-compress due to JenkinsResultsParserUtil ant usage

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -56,6 +56,7 @@
 	<classpathentry kind="lib" path="lib/development/com.liferay.jenkins.results.parser.jar"/>
 	<classpathentry kind="lib" path="lib/development/com.liferay.poshi.core.jar"/>
 	<classpathentry kind="lib" path="lib/development/commons-collections4.jar"/>
+	<classpathentry kind="lib" path="lib/development/commons-compress.jar"/>
 	<classpathentry kind="lib" path="lib/development/commons-lang3.jar"/>
 	<classpathentry kind="lib" path="lib/development/dtddoc.jar"/>
 	<classpathentry kind="lib" path="lib/development/dtdparser.jar"/>

--- a/build-test.xml
+++ b/build-test.xml
@@ -4635,7 +4635,8 @@ tell application "Safari" to quit
 
 			<beanshell>
 				<![CDATA[
-					import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+					import java.nio.file.Files;
+					import java.nio.file.Paths;
 
 					public int getFileLineCount() {
 						String fileLineCount = "@{file.line.count}";
@@ -4653,7 +4654,7 @@ tell application "Safari" to quit
 						return;
 					}
 
-					String fileContent = JenkinsResultsParserUtil.read(file);
+					String fileContent = new String(Files.readAllBytes(Paths.get(file.toURI())));
 
 					String[] fileLines = fileContent.split("\n");
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -15,6 +15,7 @@
 /development/com.liferay.jenkins.results.parser.jar
 /development/com.liferay.poshi.core.jar
 /development/commons-collections4.jar
+/development/commons-compress.jar
 /development/commons-lang3.jar
 /development/db2jcc.jar
 /development/db2jcc_license_cu.jar

--- a/lib/development/dependencies.properties
+++ b/lib/development/dependencies.properties
@@ -15,6 +15,7 @@ com.liferay.ant.manifest.helper=com.liferay:com.liferay.ant.manifest.helper:1.0.
 com.liferay.jenkins.results.parser=com.liferay:com.liferay.jenkins.results.parser:1.0.1029
 com.liferay.poshi.core=com.liferay:com.liferay.poshi.core:1.0.59
 commons-collections4=org.apache.commons:commons-collections4:4.2
+commons-compress=org.apache.commons:commons-compress:1.21
 commons-lang3=org.apache.commons:commons-lang3:3.12.0
 dtddoc=net.sf.dtddoc:DTDDoc:1.1.0
 dtdparser=com.liferay:com.wutka.dtd:1.20

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -5978,6 +5978,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/commons-compress.jar</file-name>
+				<version>1.21</version>
+				<project-name>Commons Compress</project-name>
+				<project-url>http://commons.apache.org/compress</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/commons-lang3.jar</file-name>
 				<version>3.12.0</version>
 				<project-name>Commons Lang</project-name>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -187,6 +187,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/commons-compress.jar</file-name>
+				<version>1.21</version>
+				<project-name>Commons Compress</project-name>
+				<project-url>http://commons.apache.org/compress</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/commons-lang3.jar</file-name>
 				<version>3.12.0</version>
 				<project-name>Commons Lang</project-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2587,6 +2587,11 @@
 </td><td></td>
 </tr>
 <tr>
+<td nowrap="nowrap">lib/development/commons-compress.jar</td><td nowrap="nowrap">1.21</td><td nowrap="nowrap"><a href="http://commons.apache.org/compress">Commons Compress</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<br>
+</td><td></td>
+</tr>
+<tr>
 <td nowrap="nowrap">lib/development/commons-lang3.jar</td><td nowrap="nowrap">3.12.0</td><td nowrap="nowrap"><a href="http://commons.apache.org/proper/commons-lang/">Commons Lang</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -21,6 +21,7 @@ javac.classpath=\
     lib/development/com.liferay.jenkins.results.parser.jar:\
     lib/development/com.liferay.poshi.core.jar:\
     lib/development/commons-collections4.jar:\
+    lib/development/commons-compress.jar:\
     lib/development/commons-lang3.jar:\
     lib/development/dtddoc.jar:\
     lib/development/dtdparser.jar:\


### PR DESCRIPTION
@kenjiheigel @michaelhashimoto JenkinsResultsParserUtil is used in many portal ant beanshell scripts and depends on commons-compress libraries. On some machines, when beanshell invokes JenkinsResultsParserUtil methods, it tries to load all of the class dependencies. CI does not reproduce the issue, but this is affecting multiple QA local machines, so I am adding the dependency. CC @shuyangzhou