### PR TITLE
master-qa-59212

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2454,6 +2454,25 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 				<elseif>
 					<equals arg1="${app.server.type}" arg2="wildfly" />
 					<then>
+						<propertycopy from="jdbc.${database.type}.driver" name="jdbc.driver" />
+
+						<copy
+							file="${test.app.server.lib.portal.dir}/${jdbc.driver}"
+							tofile="${app.server.lib.global.dir}/${jdbc.driver}"
+						/>
+
+						<echo file="${app.server.lib.global.dir}/module.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<module name="com.liferay.portal" xmlns="urn:jboss:module:1.5">
+	<resources>
+		<resource-root path="${jdbc.driver}" />
+	</resources>
+	<dependencies>
+		<module name="javax.api" />
+		<module name="javax.transaction.api" />
+		<module name="javax.servlet.api" optional="true" />
+	</dependencies>
+</module>]]></echo>
+
 						<if>
 							<not>
 								<resourcecontains


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-59212

This is for fixing the missing database driver error on Wildfly envrionments:
```
[beanshell] [0m[31m09:15:23,698 ERROR [org.jboss.as.controller.management-operation] (Controller Boot Thread) WFLYCTL0013: Operation ("add") failed - address: ([
[beanshell]     ("subsystem" => "datasources"),
[beanshell]     ("data-source" => "LiferayPool")
[beanshell] ]) - failure description: {
[beanshell]     "WFLYCTL0412: Required services that are not installed:" => ["jboss.jdbc-driver.mysql"],
[beanshell]     "WFLYCTL0180: Services with missing/unavailable dependencies" => [
[beanshell]         "jboss.driver-demander.java:/jdbc/LiferayPool is missing [jboss.jdbc-driver.mysql]",
[beanshell]         "org.wildfly.data-source.LiferayPool is missing [jboss.jdbc-driver.mysql]"
[beanshell]     ]
[beanshell] }
```

Tested in https://github.com/zhangyan0701/liferay-portal/pull/395.
Testray results:
MariaDB: https://testray.liferay.com/home/-/testray/case_results/1956567339
MySQL: https://testray.liferay.com/home/-/testray/case_results/1957585128

The communication link failure error didn't occur. But it still happens on Weblogic and Websphere, I need more time to investigate.