### PR TITLE
LPS-167187 Uniform | Drop schema only if exists when executing create-*.sql script to postgres and sqlserver

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -8295,12 +8295,12 @@ create database lportal${database.index} character set utf8;</echo>
 						</and>
 						<then>
 							<echo file="create.sql">
-drop database lportal;
+drop database if exists lportal;
 create database lportal encoding = 'UNICODE';</echo>
 
 							<echo append="true" file="create.sql">
 
-drop database lportal${databases.size};
+drop database if exists lportal${databases.size};
 create database lportal${databases.size} encoding = 'UNICODE';</echo>
 						</then>
 					</elseif>

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -147,7 +147,7 @@ public class SQLServerDB extends BaseDB {
 	@Override
 	public String getRecreateSQL(String databaseName) {
 		return StringBundler.concat(
-			"drop database ", databaseName, ";\n", "create database ",
+			"drop database if exists ", databaseName, ";\n", "create database ",
 			databaseName, ";\n\n", "go\n\n");
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -128,7 +128,7 @@ public class PostgreSQLDB extends BaseDB {
 	@Override
 	public String getRecreateSQL(String databaseName) {
 		return StringBundler.concat(
-			"drop database ", databaseName, ";\n", "create database ",
+			"drop database if exists ", databaseName, ";\n", "create database ",
 			databaseName, " encoding = 'UNICODE';\n");
 	}
 


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-167187
Tested here: https://github.com/lucasperj/liferay-portal/pull/309