### PR TITLE
LPS-166087, LPS-166760, LPS-158742 Fix API calls when using DB Partitioning

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUser.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUser.macro
@@ -187,10 +187,19 @@ definition {
 		var portalInstanceName = JSONUserSetter.setPortalInstanceName(portalURL = "${portalURL}");
 
 		var userId = JSONUserSetter.setUserId(
+			creatorEmailAddress = "${creatorEmailAddress}",
+			creatorPassword = "${creatorPassword}",
 			portalInstanceName = "${portalInstanceName}",
+			specificURL = "${portalURL}",
 			userEmailAddress = "${userEmailAddress}");
 
-		JSONUserAPI._agreeToTermsAndAnswerReminderQuery(userId = "${userId}");
+		JSONUserAPI._agreeToTermsAndAnswerReminderQuery(
+			creatorEmailAddress = "${creatorEmailAddress}",
+			creatorPassword = "${creatorPassword}",
+			portalInstanceName = "${portalInstanceName}",
+			specificURL = "${portalURL}",
+			userEmailAddress = "${userEmailAddress}",
+			userId = "${userId}");
 	}
 
 	macro agreeToTermsAndAnswerReminderQueryByScreenName {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
@@ -95,16 +95,32 @@ definition {
 			var portalURL = JSONCompany.getPortalURL();
 		}
 
+		if (!(isSet(creatorEmailAddress))) {
+			if (isSet(specificURL)) {
+				var creatorEmailAddress = "${userEmailAddress}";
+			}
+			else {
+				var creatorEmailAddress = "test@liferay.com";
+			}
+		}
+		else {
+			var creatorEmailAddress = "${creatorEmailAddress}";
+		}
+
+		if (!(isSet(creatorPassword))) {
+			var creatorPassword = "test";
+		}
+
 		var curl = '''
 			${portalURL}/api/jsonws/user/update-agreed-to-terms-of-use/user-id/${userId}/agreed-to-terms-of-use/true \
-				-u test@liferay.com:test
+				-u ${creatorEmailAddress}:${creatorPassword}
 		''';
 
 		com.liferay.poshi.runner.util.JSONCurlUtil.post("${curl}");
 
 		var curl = '''
 			${portalURL}/api/jsonws/user/update-reminder-query/user-id/${userId}/question/what-is-your-father%27s-middle-name/answer/test \
-				-u test@liferay.com:test
+				-u ${creatorEmailAddress}:${creatorPassword}
 		''';
 
 		com.liferay.poshi.runner.util.JSONCurlUtil.post("${curl}");
@@ -221,7 +237,15 @@ definition {
 		}
 
 		if (!(isSet(creatorEmailAddress))) {
-			var creatorEmailAddress = "test@liferay.com";
+			if (isSet(specificURL)) {
+				var creatorEmailAddress = "${userEmailAddress}";
+			}
+			else {
+				var creatorEmailAddress = "test@liferay.com";
+			}
+		}
+		else {
+			var creatorEmailAddress = "${creatorEmailAddress}";
 		}
 
 		if (!(isSet(creatorPassword))) {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
@@ -103,9 +103,6 @@ definition {
 				var creatorEmailAddress = "test@liferay.com";
 			}
 		}
-		else {
-			var creatorEmailAddress = "${creatorEmailAddress}";
-		}
 
 		if (!(isSet(creatorPassword))) {
 			var creatorPassword = "test";
@@ -243,9 +240,6 @@ definition {
 			else {
 				var creatorEmailAddress = "test@liferay.com";
 			}
-		}
-		else {
-			var creatorEmailAddress = "${creatorEmailAddress}";
 		}
 
 		if (!(isSet(creatorPassword))) {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserSetter.macro
@@ -96,6 +96,7 @@ definition {
 			creatorEmailAddress = "${creatorEmailAddress}",
 			creatorPassword = "${creatorPassword}",
 			portalInstanceName = "${portalInstanceName}",
+			specificURL = "${specificURL}",
 			userEmailAddress = "${userEmailAddress}");
 
 		return "${userId}";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLogContext.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLogContext.testcase
@@ -22,7 +22,7 @@ definition {
 		Log.viewLogFileContentPresent(logContent = "ExampleText=ExampleText");
 	}
 
-	@description = "LPS-158742. Given custom log4j is not added to portal and log context is not enabled. Then log lines will not be marked."
+	@description = "LPS-158742. Given custom log4j is added to portal and log context is enabled. Then log lines will be marked with default context name."
 	@priority = "4"
 	test LogOutputReturnsMarkedWithDefaultName {
 		property custom.properties = "upgrade.log.context.enabled=true${line.separator}upgrade.database.auto.run=true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
@@ -1018,6 +1018,7 @@ definition {
 	@priority = "5"
 	test AddNewExperienceOrganizationRegionSegment {
 		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "ExperienceCreateExperience#AddNewExperienceOrganizationRegionSegment";
 
 		task ("Add a Organization via JSONWS") {
 			JSONOrganization.addOrganization(
@@ -1914,6 +1915,7 @@ definition {
 	@priority = "4"
 	test AddNewExperienceSessionIPGeocoderCountry {
 		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "ExperienceCreateExperience#AddNewExperienceSessionIPGeocoderCountry";
 
 		task ("Add a session IP Geocoder Country segment") {
 			JSONSegmentsentry.addSegment(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
@@ -1888,6 +1888,8 @@ definition {
 				userFirstName = "userfn",
 				userLastName = "userln",
 				userScreenName = "usersn");
+
+			User.editPassword(newPassword = "test");
 		}
 
 		task ("Login with userea user") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/SegmentationCreateSegment.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/SegmentationCreateSegment.testcase
@@ -381,6 +381,7 @@ definition {
 	@uitest
 	test AddSegmentByOrganizationRegion {
 		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "SegmentationCreateSegment#AddSegmentByOrganizationRegion";
 
 		task ("Add user") {
 			JSONUser.addUser(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166087
- Fix log in JSON macros
- API calls were unable to grab users from isolated instances
- Tested here: https://github.com/susanchen3/liferay-portal/pull/91

https://issues.liferay.com/browse/LPS-166760
- Isolate Segmentation tests
- Tests were passing locally > maybe bad cleanup on CI?
- Tested here: https://github.com/susanchen3/liferay-portal/pull/92#issuecomment-1308160608

https://issues.liferay.com/browse/LPS-158742
- Update upgrade context log test description