### PR TITLE
LPS-168040 Disable upgrade and db partitioning tests on release

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -6391,7 +6391,9 @@ test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-db-partitio
                 (database.types ~ mysql)\
             ) AND \
             (portal.release == true)\
-        )
+        ) AND \
+        (database.partition.enabled == null) AND \
+        (testray.main.component.name != "Database Partitioning")
 
     test.batch.run.property.query[functional-bundle-tomcat-mysql80-jdk8][portal-release][portal]=\
         (portal.smoke == true)

--- a/test.properties
+++ b/test.properties
@@ -6278,7 +6278,8 @@ test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-db-partitio
             (app.server.types ~ tomcat) AND \
             (database.types ~ db2) AND \
             (portal.release == true)\
-        )
+        ) AND \
+        (data.archive.type == null)
 
     test.batch.run.property.query[functional-bundle-tomcat-db2111-jdk8][portal-release]=\
         (\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168040
- Disable upgrade tests on db2 11.5
- Disable db partitioning tests on mysql 8.0