### PR TITLE
LPS-171559 Improvements for upgrade performance test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -4,7 +4,6 @@ definition {
 	property app.server.types = "tomcat";
 	property database.partition.enabled = "true";
 	property database.types = "mysql";
-	property liferay.online.properties = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
@@ -31,6 +30,7 @@ definition {
 	@priority = "5"
 	test CanUpgradePartitionedDatabase7413U33 {
 		property data.archive.type = "data-archive-portal-partition";
+		property liferay.online.properties = "true";
 		property portal.upgrades = "true";
 		property portal.version = "7.4.13.u33";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -12,6 +12,7 @@ definition {
 
 	@priority = "5"
 	test CanUpgradeLargePartitionedDatabase7413U47 {
+		property ci.retries.disabled = "true";
 		property custom.properties = "upgrade.database.auto.run=true";
 		property custom.startup.timeout = "300";
 		property data.archive.type = "data-archive-portal-partition-large";
@@ -20,6 +21,7 @@ definition {
 		property portal.upstream = "false";
 		property portal.version = "7.4.13.u47";
 		property skip.upgrade-legacy-database = "true";
+		property test.assert.warning.exceptions = "false";
 
 		User.firstLoginUI(
 			password = "1234",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -11,7 +11,7 @@ definition {
 	property testray.main.component.name = "Database Partitioning";
 
 	@priority = "5"
-	test CanUpgradeLargePartitionedDatabase7413U47 {
+	test CanAutoUpgradeLargePartitionedDatabase7413U47 {
 		property ci.retries.disabled = "true";
 		property custom.properties = "upgrade.database.auto.run=true";
 		property custom.startup.timeout = "300";
@@ -21,6 +21,23 @@ definition {
 		property portal.upstream = "false";
 		property portal.version = "7.4.13.u47";
 		property skip.upgrade-legacy-database = "true";
+		property test.assert.warning.exceptions = "false";
+
+		User.firstLoginUI(
+			password = "1234",
+			specificURL = "http://www.able.com:8080",
+			userEmailAddress = "test@www.able.com");
+	}
+
+	@priority = "5"
+	test CanUpgradeLargePartitionedDatabase7413U47 {
+		property ci.retries.disabled = "true";
+		property custom.startup.timeout = "300";
+		property data.archive.type = "data-archive-portal-partition-large";
+		property minimum.slave.ram = "24";
+		property portal.release = "false";
+		property portal.upstream = "false";
+		property portal.version = "7.4.13.u47";
 		property test.assert.warning.exceptions = "false";
 
 		User.firstLoginUI(


### PR DESCRIPTION
- Removed testing LOL properties since "this test should be valid for all installations. Only the tests executed in LXC should have those properties" - Alberto 
   - https://liferay.slack.com/archives/G01PX1Z5H63/p1671459500480879?thread_ts=1671429508.267999&cid=G01PX1Z5H63
- Removed failure on warnings because we are testing performance
   - [LPS-171376](https://issues.liferay.com/browse/LPS-171376) has been filed to address the warnings encountered
- Limit the tests to run once on CI if they fail out 
- Add test to run with the upgrade tool alongside having the auto-upgrade test