### PR TITLE
LPS-172797 Add U61 to tomcat 9.0.68

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6411,6 +6411,7 @@ go</echo>
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u58" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u59" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u60" />
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u61" />
 					</or>
 					<then>
 						<var name="app.server.tomcat.version" value="9.0.68" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-172797

U61 also uses tomcat 9.0.68. Need to add it for continuous upgrade tests for U62.

cc: @Kvale1733 