### PR TITLE
LPS-175281 Ability to generate the upgrade report in the standard log output as log context information | Functional Automation

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Log.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Log.macro
@@ -1,6 +1,6 @@
 definition {
 
-	macro viewLogFileContentNotPresent {
+	macro getLogFileContent {
 		AntCommand(
 			locator1 = "build-test.xml",
 			value1 = "copy-log-file");
@@ -8,6 +8,12 @@ definition {
 		var liferayHome = PropsUtil.get("liferay.home.dir.name");
 
 		var fileContent = FileUtil.read("${liferayHome}/liferay.log");
+
+		return ${fileContent};
+	}
+
+	macro viewLogFileContentNotPresent {
+		var fileContent = Log.getLogFileContent();
 
 		if (contains(${fileContent}, ${logContent})) {
 			fail("${logContent} is present in portal log.");
@@ -15,13 +21,7 @@ definition {
 	}
 
 	macro viewLogFileContentPresent {
-		AntCommand(
-			locator1 = "build-test.xml",
-			value1 = "copy-log-file");
-
-		var liferayHome = PropsUtil.get("liferay.home.dir.name");
-
-		var fileContent = FileUtil.read("${liferayHome}/liferay.log");
+		var fileContent = Log.getLogFileContent();
 
 		if (!(contains(${fileContent}, ${logContent}))) {
 			fail("${logContent} is not present in portal log.");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLogContext.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeLogContext.testcase
@@ -35,6 +35,10 @@ definition {
 		task ("Verify that no key-value mark is printed when it's not related with Upgrade Framework") {
 			Log.viewLogFileContentPresent(logContent = "{}");
 		}
+
+		task ("Verify upgrade report is not generated in console output") {
+			AssertConsoleTextNotPresent(value1 = "Upgrade report generated in");
+		}
 	}
 
 	@description = "LPS-158742. Given custom log4j is not added to portal and log context is enabled. Then log lines will not be marked."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -332,6 +332,94 @@ definition {
 		}
 	}
 
+	@description = "LPS-158743: Upgrade report is generated in the console using log context format"
+	@priority = 4
+	test ReportGeneratedWithLogContext {
+		property custom.properties = "upgrade.database.auto.run=true${line.separator}upgrade.report.enabled=true${line.separator}upgrade.log.context.enabled=true";
+		property log.context.enabled = "true";
+		property skip.start.app.server = "false";
+		property skip.upgrade-legacy-database = "true";
+		property upgrade.reports.enabled = "false";
+
+		task ("Check report is generated console") {
+			AntCommand(
+				locator1 = "build-test.xml",
+				value1 = "copy-log-file");
+
+			var liferayHome = PropsUtil.get("liferay.home.dir.name");
+
+			var fileContent = FileUtil.read("${liferayHome}/liferay.log");
+
+			if (!(contains(${fileContent}, "upgrade.report.execution.time="))) {
+				fail("upgrade.report.execution.time is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.database.version=mysql"))) {
+				fail("upgrade.report.database.version is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.portal.expected.build.number=7413"))) {
+				fail("upgrade.report.portal.expected.build.number is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.portal.expected.schema.version="))) {
+				fail("upgrade.report.portal.expected.schema.version is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.portal.final.build.number=7413"))) {
+				fail("upgrade.report.portal.final.build.number is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.portal.final.schema.version="))) {
+				fail("upgrade.report.portal.final.schema.version is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.portal.initial.build.number=7413"))) {
+				fail("upgrade.report.portal.initial.build.number is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.portal.initial.schema.version="))) {
+				fail("upgrade.report.portal.initial.schema.version is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.document.library.storage.size="))) {
+				fail("upgrade.report.document.library.storage.size is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.property.dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore"))) {
+				fail("upgrade.report.property.dl.store.impl is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.longest.upgrade.processes=["))) {
+				fail("upgrade.report.longest.upgrade.processes is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.tables.initial.final.rows=["))) {
+				fail("upgrade.report.tables.initial.final.rows is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.errors=[]"))) {
+				fail("upgrade.report.errors is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.warnings=[]"))) {
+				fail("upgrade.report.warnings is not present in portal log.");
+			}
+
+			if (!(contains(${fileContent}, "upgrade.report.osgi.status=There are no pending upgrades"))) {
+				fail("upgrade.report.osgi.status is not present in portal log.");
+			}
+		}
+
+		task ("Check report file is generated") {
+			var reportFileExists = FileUtil.exists("${liferayHome}/reports/upgrade_report.info");
+
+			if (${reportFileExists} != "true") {
+				fail("Upgrade report not found in ${liferayHome}/reports");
+			}
+		}
+	}
+
 	@description = "LPS-154683: Upgrade Report is not created when property is not set to true"
 	@priority = 4
 	test ReportNotGenerated {
@@ -412,6 +500,22 @@ definition {
 
 				fail("Renamed upgrade report does not match original upgrade report.");
 			}
+		}
+	}
+
+	@description = "LPS-158743: Upgrade report trace line is generated in the console"
+	@priority = 3
+	test ReportTraceLineLogged {
+		property custom.properties = "upgrade.database.auto.run=true${line.separator}upgrade.report.enabled=true${line.separator}upgrade.log.context.enabled=true";
+		property log.context.enabled = "true";
+		property skip.start.app.server = "false";
+		property skip.upgrade-legacy-database = "true";
+		property upgrade.reports.enabled = "false";
+
+		task ("Check report is generated console") {
+			var liferayHome = PropsUtil.get("liferay.home.dir.name");
+
+			AssertConsoleTextPresent(value1 = "Upgrade report generated in ${liferayHome}/reports/upgrade_report.info");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -330,6 +330,14 @@ definition {
 				fail("New upgrade report contains unexpected upgrades.");
 			}
 		}
+
+		task ("Verify upgrade report is not generated in console output in log context format") {
+			var fileContent = Log.getLogFileContent();
+
+			if (contains(${fileContent}, "upgrade.component=")) {
+				fail("Upgrade report is present in portal log.");
+			}
+		}
 	}
 
 	@description = "LPS-158743: Upgrade report is generated in the console using log context format"
@@ -342,13 +350,7 @@ definition {
 		property upgrade.reports.enabled = "false";
 
 		task ("Check report is generated console") {
-			AntCommand(
-				locator1 = "build-test.xml",
-				value1 = "copy-log-file");
-
-			var liferayHome = PropsUtil.get("liferay.home.dir.name");
-
-			var fileContent = FileUtil.read("${liferayHome}/liferay.log");
+			var fileContent = Log.getLogFileContent();
 
 			if (!(contains(${fileContent}, "upgrade.report.execution.time="))) {
 				fail("upgrade.report.execution.time is not present in portal log.");
@@ -412,6 +414,8 @@ definition {
 		}
 
 		task ("Check report file is generated") {
+			var liferayHome = PropsUtil.get("liferay.home.dir.name");
+
 			var reportFileExists = FileUtil.exists("${liferayHome}/reports/upgrade_report.info");
 
 			if (${reportFileExists} != "true") {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-158743

Tested here: https://github.com/susanchen3/liferay-portal/pull/156

Previous Review https://github.com/vicnate5/liferay-portal/pull/2290#issuecomment-1500701789: 

> 1. Good call not re-getting the log for each assertion in ReportGeneratedWithLogContext. Can you also make a getter macro? getLogFileContent. It should return it as a variable. This can then be used inside of viewLogFileContentPresent macro and ReportGeneratedWithLogContext testcase to make it cleaner.
> 
> 2. For https://github.com/vicnate5/liferay-portal/commit/84db2bdee80ebe35695ce5678628ed0ef011e35b and https://github.com/vicnate5/liferay-portal/commit/8c87ee8617bccd26079c585d40667082df520492 is this intentionally checking the XML log file (instead of the LOG log file)? I would also simplify it to only check "upgrade.component=" so it check any possible usage.
> 
> 3. Is the *.xml log file ever affected by any of this? Note that Poshi always checks the xml file by default (that is why we created Log.macro)

1. :heavy_check_mark: 
2. I made a mistake, this should check the LOG log file. https://github.com/vicnate5/liferay-portal/commit/fc384a97ecdd1caa7f554ca31ed488b01a918cb1 uses log context, so I can't just check for "upgrade.component=". I've modified to check for the report trace line. 
3. The *.xml log file is affected, but with the current implementation it only checks **[message](https://github.com/liferay/liferay-portal/blob/master/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java#L470)** 
```
<log4j:message><![CDATA[Upgrade report generated in /home/susan/Desktop/master/master-portal/../bundles/reports/upgrade_report.info]]></log4j:message>
``` 
These log messages we are checking are stored in **data** 
```
<log4j:data name="upgrade.report.database.version" value="mysql 5.7"/>
```