### PR TITLE
LRQA-80318 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/Clustering.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/Clustering.testcase
@@ -397,24 +397,20 @@ definition {
 
 		ServerAdministration.addCategoryLogLevels(
 			categoryLevel = "DEBUG",
-			categoryName = "com.liferay.portal.cluster");
+			categoryName = "com.liferay.portal.servlet.filters.autologin.AutoLoginFilter");
 
 		ServerAdministration.viewCategoryLogLevels(
 			categoryLevel = "DEBUG",
-			categoryName = "com.liferay.portal.cluster");
+			categoryName = "com.liferay.portal.servlet.filters.autologin.AutoLoginFilter");
 
-		User.logoutPG(
-			password = "test",
-			userEmailAddress = "test@liferay.com");
+		for (var serverPort : list "8080,9080,10080") {
+			User.loginPG(
+				nodePort = ${serverPort},
+				password = "test",
+				userEmailAddress = "test@liferay.com");
 
-		User.loginPG(
-			nodePort = 9080,
-			password = "test",
-			userEmailAddress = "test@liferay.com");
-
-		for (var serverPort : list "8080,9080") {
 			Clustering.viewTextPresentOnSpecificNode(
-				expectedText = "Send multicast message",
+				expectedText = "com.liferay.portal.servlet.filters.autologin.AutoLoginFilter /web/guest",
 				nodePort = ${serverPort});
 		}
 	}
@@ -440,11 +436,11 @@ definition {
 
 		ServerAdministration.addCategoryLogLevels(
 			categoryLevel = "DEBUG",
-			categoryName = "com.liferay.portal.cluster");
+			categoryName = "com.liferay.portal.servlet.filters.autologin.AutoLoginFilter");
 
 		ServerAdministration.viewCategoryLogLevels(
 			categoryLevel = "DEBUG",
-			categoryName = "com.liferay.portal.cluster");
+			categoryName = "com.liferay.portal.servlet.filters.autologin.AutoLoginFilter");
 
 		for (var serverPort : list "8080,9080,10080") {
 			User.loginPG(
@@ -453,7 +449,7 @@ definition {
 				userEmailAddress = "test@liferay.com");
 
 			Clustering.viewTextPresentOnSpecificNode(
-				expectedText = "Send multicast message",
+				expectedText = "com.liferay.portal.servlet.filters.autologin.AutoLoginFilter /web/guest",
 				nodePort = ${serverPort});
 		}
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-80318

Tested here: https://github.com/Kvale1733/liferay-portal/pull/332

The log size is significantly reduced. The master node log for instance is over 10MB on master. With these changes it's only 302.2kB. And this log category won't output text continuously if the test were to run longer for any reason. It only adds a couple lines. This still asserts the log level was updated for all nodes on both tests.