### PR TITLE
LPS-180931 Uniform Automated test | Update Upgrade testray main component names to match with the current used

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/test.properties
+++ b/modules/apps/portal/portal-upgrade-impl/test.properties
@@ -2,4 +2,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Upgrades Core
+    testray.main.component.name=Database Upgrade Framework

--- a/modules/apps/portal/portal-upgrade-test/test.properties
+++ b/modules/apps/portal/portal-upgrade-test/test.properties
@@ -2,4 +2,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Upgrades Core
+    testray.main.component.name=Database Upgrade Framework


### PR DESCRIPTION
Issue link: https://issues.liferay.com/browse/LPS-180931
Tested at: https://github.com/lucasperj/liferay-portal/pull/330 | Passing [here](https://testray.liferay.com/home/-/testray/case_results/index?p_p_state=normal&orderByCol=status_sortable&orderByType=asc&testrayBuildId=2265149366&testrayTeamId=1860204161&testrayComponentId=1951716086&testrayRunId=2265151398&testrayCaseName=com.liferay.portal.upgrade.test.UpgradeCTModelTest) - Note that this is filtered by time and component, being the respective desired ones, but, the reason it's still saying Upgrade Core and Triage is because after the PR run, testray will load in results from other PRs to the default setting, so basically the database upgrade framework is reverted back to Upgrades Core since the change isn't in upstream yet