### PR TITLE
LPS-184744 Increase maximum pool size to prevent timeout

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -641,7 +641,7 @@ jdbc.default.password=${database.password}
 // HikariCP
 
 jdbc.default.connectionTimeout=600000
-jdbc.default.maximumPoolSize=30
+jdbc.default.maximumPoolSize=40
 jdbc.default.minimumIdle=0]]></echo>
 
 			<if>
@@ -11260,7 +11260,7 @@ login.secure.forgot.password=false</echo>
 					// HikariCP
 
 					jdbc.default.connectionTimeout=600000
-					jdbc.default.maximumPoolSize=30
+					jdbc.default.maximumPoolSize=40
 					jdbc.default.minimumIdle=0
 
 					initial.system.check.enabled=true</echo>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-184744

----

Not sure if we should increase the pool size again. I've only seen the connection error a few times since [LPS-179949](https://issues.liferay.com/browse/LPS-179949) was merged. 