### PR TITLE
LRQA-80725 | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2939,6 +2939,17 @@ include-and-override=portal-liferay-online-limit.properties</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-ms-exchange-configuration">
+		<sequential>
+			<echo file="${liferay.home}/osgi/configs/com.liferay.mail.outlook.auth.connector.provider.internal.configuration.MailOutlookAuthConnectorCompanyConfiguration.config">
+clientId=&quot;${ms.exchange.client.id}&quot;
+clientSecret=&quot;${ms.exchange.client.secret}&quot;
+pop3ConnectionEnabled=B"true"
+smtpConnectionEnabled=B"true"
+tenantId=&quot;${ms.exchange.tenant.id}&quot;</echo>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-patching-tool">
 		<attribute default="${app.server.parent.dir}/patching-tool" name="patching.tool.dir" />
 
@@ -11107,6 +11118,10 @@ ${update.properties}</echo>
 </Configuration>]]></echo>
 	</target>
 
+	<target name="prepare-ms-exchange-configuration">
+		<prepare-ms-exchange-configuration />
+	</target>
+
 	<target name="prepare-osgi-module-configurations">
 		<get-testcase-property property.name="custom.element.client.extension.created" />
 
@@ -11435,6 +11450,45 @@ company.default.web.id=www.able.com</echo>
 			</or>
 			<then>
 				<get-testcase-property property.name="ibm.store.enabled" />
+			</then>
+		</if>
+
+		<if>
+			<or>
+				<equals arg1="ms.exchange.enabled" arg2="" />
+				<not>
+					<isset property="ms.exchange.enabled" />
+				</not>
+			</or>
+			<then>
+				<get-testcase-property property.name="ms.exchange.enabled" />
+			</then>
+		</if>
+
+		<if>
+			<equals arg1="${ms.exchange.enabled}" arg2="true" />
+
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+mail.session.mail=true
+mail.session.mail.pop3.host=outlook.office365.com
+mail.session.mail.pop3.port=995
+mail.session.mail.pop3.user=qa-exchange-pop-test@liferay.onmicrosoft.com
+mail.session.mail.smtp.host=smtp.office365.com
+mail.session.mail.smtp.port=587
+mail.session.mail.smtp.user=qa-exchange-pop-test@liferay.onmicrosoft.com
+mail.session.mail.store.protocol=pop3
+
+pop.server.subdomain=
+pop.server.notifications.enabled=true
+				</echo>
+
+				<replace
+					file="portal-impl/src/portal-ext.properties"
+				>
+					<replacetoken>test@liferay.com</replacetoken>
+					<replacevalue>qa-exchange-pop-test@liferay.onmicrosoft.com</replacevalue>
+				</replace>
 			</then>
 		</if>
 
@@ -15216,6 +15270,15 @@ mail.send.blacklist=</echo>
 				<ant antfile="build-test-openam.xml" target="delete-openam-config" />
 
 				<ant antfile="build-test-openam.xml" target="setup-openam" />
+			</then>
+		</if>
+
+		<get-testcase-property property.name="ms.exchange.enabled" />
+
+		<if>
+			<equals arg1="${ms.exchange.enabled}" arg2="true" />
+			<then>
+				<prepare-ms-exchange-configuration />
 			</then>
 		</if>
 

--- a/modules/apps/mail/mail-outlook-auth-connector-provider/src/testFunctional/tests/MSExchange.testcase
+++ b/modules/apps/mail/mail-outlook-auth-connector-provider/src/testFunctional/tests/MSExchange.testcase
@@ -1,0 +1,116 @@
+@component-name = "core-infrastructure"
+definition {
+
+	property ms.exchange.enabled = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Portal Configuration";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		ServerAdministration.openServerAdmin();
+
+		Navigator.gotoNavItem(navItem = "Mail");
+
+		Check(locator1 = "ServerAdministrationMail#INCOMING_SECURE_NETWORK_CONNECTION_CHECKBOX");
+
+		AssertClick(
+			locator1 = "Button#SAVE",
+			value1 = "Save");
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "Verify users can view and reply to message board threads via email with Microsoft Exchange Server."
+	@priority = 5
+	test MSExhangeViewMBThreadAndReply {
+		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property test.name.skip.portal.instance = "MSExchange#MSExhangeViewMBThreadAndReply";
+
+		task ("Given a gmail user with permission to add and post on message boards") {
+			JSONUser.addUserWithRole(
+				roleTitle = "Administrator",
+				userEmailAddress = PropsUtil.get("email.address.3"),
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "usersn");
+		}
+
+		task ("And given the user creates a message board") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = PropsUtil.get("email.address.3"),
+				userLoginFullName = "userfn userln");
+
+			MessageBoardsAdmin.openMessageBoardsAdmin(siteURLKey = "guest");
+
+			MessageboardsThread.addCP(
+				threadBody = "MB Thread Message Body",
+				threadSubject = "MB Thread Message Subject");
+		}
+
+		task ("And given a user has replied to the message board") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "test@liferay.com",
+				userLoginFullName = "Test Test");
+
+			MessageBoardsAdmin.openMessageBoardsAdmin(siteURLKey = "guest");
+
+			MessageboardsThread.gotoCP(threadSubject = "MB Thread Message Subject");
+
+			MessageboardsThread.replyCP(
+				threadReplyBody = "Message Boards Body Reply",
+				threadSubject = "MB Thread Message Subject");
+
+			Button.clickPublish();
+		}
+
+		task ("When the owner of the message board logs in to their email account") {
+			Gmail.login(
+				userEmailAddress = PropsUtil.get("email.address.3"),
+				userPassword = PropsUtil.get("email.password.3"));
+
+			WaitForElementPresent(locator1 = "Gmail#INBOX");
+		}
+
+		task ("Then they can view the reply in their inbox") {
+			Gmail.gotoHtmlMode();
+
+			Gmail.viewMail(
+				emailFromUserName = "userfn userln",
+				gmailAssetType = "userln (2)",
+				gmailMessageBody = "Message Boards Body Reply",
+				gmailMessageTitle = " MB Thread Message Subject",
+				viewReply = "true");
+		}
+
+		task ("When the user submits a response via email") {
+			Gmail.replyMail(gmailReplyMessage = "MB Thread Message Subject Reply");
+		}
+
+		task ("Then the response is also added on the message board") {
+
+			// Pausing 30 seconds due to LRQA-80725
+
+			Pause(locator1 = 30000);
+
+			MessageBoardsAdmin.openMessageBoardsAdmin(siteURLKey = "guest");
+
+			MessageboardsThread.gotoCP(threadSubject = "MB Thread Message Subject");
+
+			MessageboardsThread.viewReplyCP(
+				threadBody = "MB Thread Message Subject Reply",
+				threadSubject = "MB Thread Message Subject",
+				userName = "userfn userln");
+		}
+	}
+
+}

--- a/portal-web/poshi.properties
+++ b/portal-web/poshi.properties
@@ -29,6 +29,7 @@ test.dirs=\
     ../modules/apps/layout/layout-admin-web-test/src/testFunctional,\
     ../modules/apps/layout/layout-content-page-editor-web-test/src/testFunctional,\
     ../modules/apps/layout/layout-seo-web-test/src/testFunctional,\
+    ../modules/apps/mail/mail-outlook-auth-connector-provider/src/testFunctional,\
     ../modules/apps/object/object-rest-test/src/testFunctional,\
     ../modules/apps/object/object-test/src/testFunctional,\
     ../modules/apps/on-demand-admin/on-demand-admin-test/src/testFunctional,\

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Gmail.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Gmail.macro
@@ -207,6 +207,10 @@ definition {
 			Click(locator1 = "Gmail#GMAIL_HTML_MODE_MESSAGE_SHOW_QUOTED_TEXT_LINK");
 		}
 
+		if (isSet(viewReply)) {
+			Refresh();
+		}
+
 		AssertTextEquals.assertPartialText(
 			locator1 = "Gmail#GMAIL_HTML_MODE_MESSAGE_BODY_GREETING",
 			value1 = ${gmailMessageBody});

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Gmail.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Gmail.path
@@ -247,17 +247,17 @@
 </tr>
 <tr>
 	<td>GMAIL_HTML_MODE_MESSAGE_TITLE</td>
-	<td>//tr[contains(.,'${key_gmailAssetType}')]//h2/font/b</td>
+	<td>//tr//h2/font/b</td>
 	<td></td>
 </tr>
 <tr>
 	<td>GMAIL_HTML_MODE_MESSAGE_BODY_GREETING</td>
-	<td>//tr[contains(.,'${key_gmailAssetType}')]//td//div[@class='msg']</td>
+	<td>//tr//td//div[@class='msg']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>GMAIL_HTML_MODE_MESSAGE_BODY</td>
-	<td>//tr[contains(.,'${key_gmailAssetType}')]//td//div[@class='msg']</td>
+	<td>//tr//td//div[@class='msg']</td>
 	<td></td>
 </tr>
 <tr>
@@ -312,7 +312,7 @@
 </tr>
 <tr>
 	<td>GMAIL_HTML_MODE_MESSAGE_BODY_CLOSING</td>
-	<td>//tr[contains(.,'${key_gmailAssetType}')]//td//div[@class='msg']</td>
+	<td>//tr//td//div[@class='msg']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Gmail.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Gmail.path
@@ -29,6 +29,11 @@
 <!--LOGIN-->
 
 <tr>
+	<td>INBOX</td>
+	<td>//body[contains(.,'Inbox')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>LOGIN_EMAIL_FIELD</td>
 	<td>//input[contains(@type,'email')]</td>
 	<td></td>

--- a/test.properties
+++ b/test.properties
@@ -9835,6 +9835,7 @@
         marketplace.app.acceptance,\
         marketplace.staging.enabled,\
         minimum.slave.ram,\
+        ms.exchange.enabled,\
         oauth2.application.enabled,\
         openam.enabled,\
         operating.system.types,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-80725

So I was wrong about the property to set the secure connection. Doesn't seem to be working now. I had to set this in the UI at setup, so the errors still appear. To avoid that we would have the set those properties in the UI at the cost of some efficiency. Or there really might be a property to set this but I just couldn't find it if it exists.

However, this doesn't seem to be affecting the functionality as the test still passes. Messages are sent to the email and vice versa. The test passes locally.

I had to set "admin.email.from.address=qa-exchange-pop-test@liferay.onmicrosoft.com" because without it I get an error like [this ](https://answers.microsoft.com/en-us/msoffice/forum/all/failed-to-send-email-554-52252/8a01dd44-58b2-4ca8-8a4d-6119d70912ea). Seems setting that property to the email from the account avoids that. Looks like this doesn't work with admin email set as test@liferay.com. The admin needs to be the same as the account. It can't be sent as test@liferay.com. I think from what I [read](https://pitstop.manageengine.com/portal/en/kb/articles/mail-sending-failed) this might be able to be changed in the in the office account.

But this still throws this error since the account wasn't actually created or updated in the portal. But it doesn't seem to affect the functionality either. I can't make an account with that email because it states that the email is reserved.
```
	... 5 more
2023-05-24 18:33:28.605 ERROR [liferay/scheduler_dispatch-5][MessageListenerImpl:117] Unable to process message: com.sun.mail.pop3.POP3Message@5796baf2
com.liferay.portal.kernel.exception.NoSuchUserException: No User exists with the key {companyId=20096, emailAddress=microsoftexchange329e71ec88ae4615bbc36ab6ce41109e@liferay.onmicrosoft.com}
	at com.liferay.portal.service.persistence.impl.UserPersistenceImpl.findByC_EA(UserPersistenceImpl.java:4822) ~[portal-impl.jar:?]
	at com.liferay.portal.service.impl.UserLocalServiceImpl.getUserByEmailAddress(UserLocalServiceImpl.java:2811) ~[portal-impl.jar:?]
```


I tested with the hardcoded gmail account email and password. Then I set it to an account we have credentials on CI based on what I saw from similar tests. To test locally you have to hard code the email of the created user and the credentails used to login to gmail.

Also it takes a while for the message board to add the response sent from email so I needed a pause.