### PR TITLE
LPS-189664 Uniform Automated test | Fix tests affected by LPS-186413

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml
@@ -76,6 +76,29 @@
 		</sequential>
 	</macrodef>
 
+	<target name="bypass-expected-upgrade-error">
+		<get-database-upgrade-client-paths />
+
+		<prepare-database-upgrade-configuration />
+
+		<execute dir="${db.upgrade.client.home}">
+			db_upgrade_client${file.suffix.bat} run
+		</execute>
+
+		<waitfor maxwait="300" maxwaitunit="second" timeoutproperty="upgrade.failed">
+			<resourcecontains
+				resource="${db.upgrade.client.log}"
+				substring="Connecting to Gogo shell because the upgrade failed or is incomplete"
+			/>
+		</waitfor>
+
+		<run-expect
+			db.upgrade.client.home="${db.upgrade.client.home}"
+			expect.file="check-upgrade-client-gogo-shell-connection.expect"
+			file.suffix.bat="${file.suffix.bat}"
+		/>
+	</target>
+
 	<target name="check-failed-gogoshell-connection">
 		<exec executable="/bin/bash" outputproperty="gogo.shell.content.out">
 			<redirector inputstring="telnet 127.0.0.1 11312 || true" />
@@ -96,37 +119,46 @@
 
 	<target name="check-failed-upgrade-log">
 		<get-database-upgrade-client-paths />
+		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.failed">
+			<resourcecontains
+				resource="${db.upgrade.client.log}"
+				substring="upgrade finished with result failure"
+			/>
+		</waitfor>
 
 		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.failed">
 			<resourcecontains
 				resource="${db.upgrade.client.log}"
-				substring="Checking to see if all upgrades have completed...${line.separator}Module upgrades have failed, have not started, or are still running."
+				substring="Connecting to Gogo shell because the upgrade failed or is incomplete"
 			/>
 		</waitfor>
 
 		<fail if="upgrade.failed" message="The upgrade process has timed out." />
-
 		<waitfor maxwait="10" maxwaitunit="second" timeoutproperty="gogoshell.timeout">
 			<resourcecontains
 				resource="${db.upgrade.client.log}"
 				substring="Type &quot;help&quot; to get available upgrade and verify commands"
 			/>
 		</waitfor>
-
 		<fail if="gogoshell.timeout" message="The Gogo shell connection did not connect as expected." />
 	</target>
 
-	<target name="check-passed-upgrade-log">
+	<target name="check-unresolved-upgrade-log">
 		<get-database-upgrade-client-paths />
-
 		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.failed">
 			<resourcecontains
 				resource="${db.upgrade.client.log}"
-				substring="Checking to see if all upgrades have completed...${line.separator}Looks good."
+				substring="upgrade finished with result unresolved"
 			/>
 		</waitfor>
 
 		<fail if="upgrade.failed" message="The upgrade process has timed out." />
+		<waitfor maxwait="10" maxwaitunit="second" timeoutproperty="gogoshell.timeout">
+			<resourcecontains
+				resource="${db.upgrade.client.log}"
+				substring="Type &quot;help&quot; to get available upgrade and verify commands"
+			/>
+		</waitfor>
 	</target>
 
 	<target name="check-upgrade-client-additional-settings">
@@ -404,7 +436,7 @@
 				<waitfor maxwait="300" maxwaitunit="second" timeoutproperty="upgrade.failed">
 					<resourcecontains
 						resource="${db.upgrade.client.log}"
-						substring="Checking to see if all upgrades have completed...${line.separator}Looks good."
+						substring="No pending upgrades to run"
 					/>
 				</waitfor>
 
@@ -577,6 +609,19 @@ upgrade.database.auto.run=false</echo>
 				/>
 			</condition>
 		</fail>
+	</target>
+
+	<target name="check-warn-upgrade-log">
+		<get-database-upgrade-client-paths />
+
+		<waitfor maxwait="150" maxwaitunit="second" timeoutproperty="upgrade.failed">
+			<resourcecontains
+				resource="${db.upgrade.client.log}"
+				substring="upgrade finished with result warning"
+			/>
+		</waitfor>
+
+		<fail if="upgrade.failed" message="The upgrade process has timed out." />
 	</target>
 
 	<target name="clean-database-upgrade-client">

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogo-shell-connection.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogo-shell-connection.expect
@@ -5,7 +5,7 @@ spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] -s
 set timeout 900
 
 expect {
-	"Connecting to Gogo shell." {}
+	"Connecting to Gogo shell" {}
 	timeout {send_user "No Gogoshell messages display";exit 2}
 }
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -54,7 +54,7 @@ definition {
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell-failed-upgrade");
 
-		WaitForConsoleTextPresent(value1 = "Failed upgrade process for module com.liferay.journal.service");
+		AssertConsoleTextPresent(value1 = "Failed upgrade process for module com.liferay.journal.service");
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-failed-upgrade-log");
 
@@ -111,7 +111,7 @@ definition {
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-upgrade-core-only");
 
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-failed-upgrade-log");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-unresolved-upgrade-log");
 
 		var schemaVersion = ValidateSmokeUpgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName = 'com.liferay.journal.web';");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -754,7 +754,7 @@ definition {
 		}
 
 		task ("Wait for upgrade to complete") {
-			AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-passed-upgrade-log");
+			AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-warn-upgrade-log");
 		}
 
 		task ("Given upgrade.report is set When the portal gets upgraded and an warn was captured during the upgrade") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/VirtualInstancesUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/VirtualInstancesUpgrade.testcase
@@ -23,10 +23,12 @@ definition {
 	}
 
 	@priority = 4
-	test ViewVirtualInstancesArchive7413U33 {
+	test ViewVirtualInstancesArchive7413U33WithAutoUpgrad {
+		property custom.properties = "upgrade.database.auto.run=true";
 		property data.archive.type = "data-archive-virtual-instances";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 		property portal.version = "7.4.13.u33";
+		property skip.upgrade-legacy-database = "true";
 		property test.assert.warning.exceptions = "false";
 
 		ValidateVirtualInstancesUpgrade.viewVirtualInstancesUpgrade();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/verifyproperties/VerifyProperties.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/verifyproperties/VerifyProperties.testcase
@@ -8,10 +8,6 @@ definition {
 	property portal.upstream = "true";
 	property testray.main.component.name = "Verify Properties";
 
-	setUp {
-		TestCase.setUpPortalInstance();
-	}
-
 	@description = "LRQA-78904: Upgrade will be stopped if Verify Properties fails when enable AutoUpgrade"
 	@priority = 3
 	test UpgradeStopsIfVerifyPropertiesFail {
@@ -44,11 +40,13 @@ definition {
 		property data.archive.type = "data-archive-reserved-friendly-url";
 		property database.types = "db2,mysql,oracle,postgresql,sqlserver";
 		property portal.version = "6.2.10.21";
+		property skip.start.app.server = "true";
+		property skip.upgrade-legacy-database = "true";
 		property test.assert.warning.exceptions = "false";
 
-		AssertConsoleTextPresent(value1 = "Detected reserved friendly URL \"/a\" Update the friendly URL for the layout with PLID");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "bypass-expected-upgrade-error");
 
-		Portlet.shutdownServer();
+		AssertConsoleTextPresent(value1 = "Detected reserved friendly URL \"/a\" Update the friendly URL for the layout with PLID");
 
 		Portlet.startServer(keepOsGiState = "true");
 


### PR DESCRIPTION
Issue link : https://liferay.atlassian.net/browse/LPS-189664

Changed the output of the upgrade tool:

- We do not print this anymore:
Checking to see if all upgrades have completed...
Looks good.
Since we relay in the UpgradeRecorder status (this was printed before this pull)

- When the upgrade fails, instead of printing this:
Module upgrades have failed, have not started, or are still running.
Connecting to Gogo shell...
We print:
Connecting to Gogo shell because the upgrade failed or is incomplete.

- We now show the Gogo Shell for any error that happens during the upgrade.
Now we can execute checks in the Gogo shell that verify errors in the Core. Previously only the changes in modules could be diagnosed but now you check both in the Gogo Shell. Please, take into account that we only open the Gogo Shell when there is a failure in Core or modules but the upgrade modules are loaded. 
- - Auto does not connect automatically since the customer can always connect on demand since the server is up

Tested at : https://github.com/lucasperj/liferay-portal/pull/352


