### PR TITLE
LRQA-81259 | master

### DIFF
--- a/build-test-local.xml
+++ b/build-test-local.xml
@@ -546,7 +546,7 @@ database.mariadb.docker.image=mariadb:${database.version}
 database.mariadb.host=localhost_mariadb
 database.mariadb.password=
 database.mariadb.schema=lportal
-database.mariadb.url=jdbc:mariadb://localhost:3308/lportal?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false
+database.mariadb.url=jdbc:mariadb://localhost:3308/lportal?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false
 database.mariadb.username=root
 database.mariadb.version=${database.version}
 database.type=mariadb

--- a/build-test.xml
+++ b/build-test.xml
@@ -2559,16 +2559,17 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 												<GlobalNamingResources>
 													<Resource
 														auth="Container"
+														dataSource.password="${database.password}"
+														dataSource.user="${database.username}"
 														description="Global Address Database"
 														driverClassName="${database.driver}"
+														factory="com.zaxxer.hikari.HikariJNDIFactory"
+														jdbcUrl="${database.url}"
 														maxActive="40"
 														maxIdle="20"
 														maxWait="1000"
 														name="jdbc/LiferayPool"
-														password="${database.password}"
 														type="javax.sql.DataSource"
-														url="${database.url}"
-														username="${database.username}"
 													/>
 											]]>
 								</replacevalue>

--- a/build-test.xml
+++ b/build-test.xml
@@ -2520,6 +2520,23 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 			<if>
 				<equals arg1="${app.server.type}" arg2="tomcat" />
 				<then>
+					<propertycopy from="jdbc.${database.type}.driver" name="jdbc.driver" />
+
+					<copy
+						file="${test.app.server.lib.portal.dir}/${jdbc.driver}"
+						tofile="${app.server.lib.global.dir}/${jdbc.driver}"
+					/>
+
+					<copy
+						file="${test.app.server.lib.portal.dir}/hikaricp.jar"
+						tofile="${app.server.lib.global.dir}/hikaricp.jar"
+					/>
+
+					<copy
+						file="${test.app.server.lib.portal.dir}/slf4j-api.jar"
+						tofile="${app.server.lib.global.dir}/slf4j-api.jar"
+					/>
+
 					<if>
 						<not>
 							<resourcecontains

--- a/build-test.xml
+++ b/build-test.xml
@@ -2522,10 +2522,26 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 				<then>
 					<propertycopy from="jdbc.${database.type}.driver" name="jdbc.driver" />
 
-					<copy
-						file="${test.app.server.lib.portal.dir}/${jdbc.driver}"
-						tofile="${app.server.lib.global.dir}/${jdbc.driver}"
-					/>
+					<if>
+						<equals arg1="${database.type}" arg2="db2" />
+						<then>
+							<copy
+								todir="${app.server.lib.global.dir}"
+							>
+								<fileset
+									dir="${test.app.server.lib.portal.dir}"
+								>
+									<include name="db2*" />
+								</fileset>
+							</copy>
+						</then>
+						<else>
+							<copy
+								file="${test.app.server.lib.portal.dir}/${jdbc.driver}"
+								tofile="${app.server.lib.global.dir}/${jdbc.driver}"
+							/>
+						</else>
+					</if>
 
 					<copy
 						file="${test.app.server.lib.portal.dir}/hikaricp.jar"

--- a/build-test.xml
+++ b/build-test.xml
@@ -2504,9 +2504,18 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 			<get-database-property property.name="database.host" />
 			<get-database-property property.name="database.password" />
 			<get-database-property property.name="database.schema" />
+			<get-database-property property.name="database.url" />
 			<get-database-property property.name="database.username" />
 
 			<get-test-app-server-lib-portal-dir />
+
+			<propertyregex
+				input="${database.url}"
+				override="true"
+				property="database.url"
+				regexp="&amp;"
+				replace="&amp;amp;"
+			/>
 
 			<if>
 				<equals arg1="${app.server.type}" arg2="tomcat" />
@@ -2541,14 +2550,11 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 							/>
 						</not>
 						<then>
-							<if>
-								<equals arg1="${database.type}" arg2="mysql" />
-								<then>
-									<replace
-										file="${app.server.dir}/conf/server.xml"
-									>
-										<replacetoken><![CDATA[<GlobalNamingResources>]]></replacetoken>
-										<replacevalue expandproperties="true">
+							<replace
+								file="${app.server.dir}/conf/server.xml"
+							>
+								<replacetoken><![CDATA[<GlobalNamingResources>]]></replacetoken>
+								<replacevalue expandproperties="true">
 											<![CDATA[
 												<GlobalNamingResources>
 													<Resource
@@ -2561,42 +2567,12 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 														name="jdbc/LiferayPool"
 														password="${database.password}"
 														type="javax.sql.DataSource"
-														url="jdbc:mysql://${database.host}/${database.schema}?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false&amp;serverTimezone=GMT&amp;dontTrackOpenResources=true&amp;holdResultsOpenOverStatementClose=true"
+														url="${database.url}"
 														username="${database.username}"
 													/>
 											]]>
-										</replacevalue>
-									</replace>
-								</then>
-								<elseif>
-									<equals arg1="${database.type}" arg2="mariadb" />
-									<then>
-										<replace
-											file="${app.server.dir}/conf/server.xml"
-										>
-											<replacetoken><![CDATA[<GlobalNamingResources>]]></replacetoken>
-											<replacevalue expandproperties="true">
-												<![CDATA[
-													<GlobalNamingResources>
-														<Resource
-															auth="Container"
-															description="Global Address Database"
-															driverClassName="${database.driver}"
-															maxActive="40"
-															maxIdle="20"
-															maxWait="1000"
-															name="jdbc/LiferayPool"
-															password="${database.password}"
-															type="javax.sql.DataSource"
-															url="jdbc:mariadb://${database.host}/${database.schema}?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false"
-															username="${database.username}"
-														/>
-												]]>
-											</replacevalue>
-										</replace>
-									</then>
-								</elseif>
-							</if>
+								</replacevalue>
+							</replace>
 						</then>
 					</if>
 				</then>
@@ -2630,18 +2606,15 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 								/>
 							</not>
 							<then>
-								<if>
-									<equals arg1="${database.type}" arg2="mysql" />
-									<then>
-										<replace
-											file="${app.server.dir}/standalone/configuration/standalone.xml"
-										>
-											<replacetoken><![CDATA[<datasources>]]></replacetoken>
-											<replacevalue expandproperties="true">
+								<replace
+									file="${app.server.dir}/standalone/configuration/standalone.xml"
+								>
+									<replacetoken><![CDATA[<datasources>]]></replacetoken>
+									<replacevalue expandproperties="true">
 												<![CDATA[
 													<datasources>
 														<datasource jndi-name="java:/jdbc/LiferayPool" pool-name="LiferayPool" enabled="true" jta="true" use-java-context="true" use-ccm="true">
-															<connection-url>jdbc:mysql://${database.host}/${database.schema}?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false&amp;serverTimezone=GMT&amp;dontTrackOpenResources=true&amp;holdResultsOpenOverStatementClose=true</connection-url>
+															<connection-url>${database.url}</connection-url>
 															<driver>${database.type}</driver>
 															<security>
 																<user-name>${database.username}</user-name>
@@ -2649,33 +2622,8 @@ sendPasswordCaptchaEnabled=&quot;false&quot;</echo>
 															</security>
 														</datasource>
 												]]>
-											</replacevalue>
-										</replace>
-									</then>
-									<elseif>
-										<equals arg1="${database.type}" arg2="mariadb" />
-										<then>
-											<replace
-												file="${app.server.dir}/standalone/configuration/standalone.xml"
-											>
-												<replacetoken><![CDATA[<datasources>]]></replacetoken>
-												<replacevalue expandproperties="true">
-													<![CDATA[
-														<datasources>
-															<datasource jndi-name="java:/jdbc/LiferayPool" pool-name="LiferayPool" enabled="true" jta="true" use-java-context="true" use-ccm="true">
-																<connection-url>jdbc:mariadb://${database.host}/${database.schema}?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false</connection-url>
-																<driver>${database.type}</driver>
-																<security>
-																	<user-name>${database.username}</user-name>
-																	<password>${database.password}</password>
-																</security>
-															</datasource>
-													]]>
-												</replacevalue>
-											</replace>
-										</then>
-									</elseif>
-								</if>
+									</replacevalue>
+								</replace>
 
 								<replace
 									file="${app.server.dir}/standalone/configuration/standalone.xml"

--- a/build-test.xml
+++ b/build-test.xml
@@ -6088,7 +6088,7 @@ tell application "Safari" to quit
 
 					<var name="app.server.bin.dir" value="${app.server.dir}/instances/liferay/bin" />
 					<var name="app.server.classes.portal.dir" value="${app.server.dir}/webapps/ROOT/WEB-INF/classes" />
-					<var name="app.server.lib.global.dir" value="${app.server.dir}/lib/ext" />
+					<var name="app.server.lib.global.dir" value="${app.server.dir}/lib" />
 					<var name="app.server.lib.portal.dir" value="${app.server.dir}/webapps/ROOT/WEB-INF/lib/" />
 					<var name="app.server.shielded-container-lib.portal.dir" value="${app.server.dir}/webapps/ROOT/WEB-INF/shielded-container-lib/" />
 					<var name="app.server.zip.url" value="http://archive.apache.org/dist/tomcat/tomcat-9/v@{app.server.version}/bin/${app.server.zip.name}" />
@@ -6619,7 +6619,7 @@ go</echo>
 			<var name="app.server.tomcat.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}" />
 			<var name="app.server.tomcat.bin.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/bin" />
 			<var name="app.server.tomcat.classes.portal.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps/ROOT/WEB-INF/classes" />
-			<var name="app.server.tomcat.lib.global.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/lib/ext" />
+			<var name="app.server.tomcat.lib.global.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/lib" />
 			<var name="app.server.tomcat.lib.portal.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps/ROOT/WEB-INF/lib" />
 			<var name="app.server.tomcat.shielded-container-lib.portal.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps/ROOT/WEB-INF/shielded-container-lib" />
 			<var name="app.server.tomcat.zip.name" value="apache-tomcat-${app.server.tomcat.version}.zip" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -15226,15 +15226,6 @@ mail.send.blacklist=</echo>
 
 		<antcall target="create-hidden-osgi-file" />
 
-		<get-testcase-property property.name="database.jndi.enabled" />
-
-		<if>
-			<equals arg1="${database.jndi.enabled}" arg2="true" />
-			<then>
-				<prepare-database-jndi />
-			</then>
-		</if>
-
 		<get-testcase-property property.name="portal.proxy.path" />
 		<propertycopy from="portal.proxy.path[${env.CI_TEST_SUITE}]" name="portal.proxy.path" silent="true" />
 
@@ -15347,6 +15338,15 @@ mail.send.blacklist=</echo>
 		<antcall inheritAll="false" target="copy-optional-jars">
 			<param name="todir" value="${test.app.server.lib.portal.dir}" />
 		</antcall>
+
+		<get-testcase-property property.name="database.jndi.enabled" />
+
+		<if>
+			<equals arg1="${database.jndi.enabled}" arg2="true" />
+			<then>
+				<prepare-database-jndi />
+			</then>
+		</if>
 
 		<get-testcase-property property.name="index.search.spell.checker.enabled" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/portalsmoke/PortalSmoke.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/portalsmoke/PortalSmoke.testcase
@@ -118,7 +118,7 @@ definition {
 		property app.server.types = "tomcat,wildfly,weblogic,websphere";
 		property ci.retries.disabled = "true";
 		property database.jndi.enabled = "true";
-		property database.types = "mariadb,mysql";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 		property portal.smoke = "false";
 
 		SignIn.signInTestSetup();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRQA-81259

Tested here: https://github.com/Kvale1733/liferay-portal/pull/378.
There were no failures:https://testray.liferay.com/home/-/testray/runs?testrayBuildId=2373549392

I know you stated otherwise but I discovered we don't actually copy any jars for Tomcat in this test. Somehow the test was still passing all this time though.

I made some changes to the configs we use for jndi to reflect what's in the documentation here: https://learn.liferay.com/w/dxp/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/setting-up-jndi-on-tomcat. As Mariano noted was needed in the LPS.

I'm not sure if there is a specific reason the test doesn't use the configuration used in that documentation.

With hikari as the factory, it does require to place the the db driver in the lib directory, along with 2 other jars. But still, I it doesn't look like there is any warning at shutdown.

It looks like this test passes on the additional db's even with the changes.