### PR TITLE
LRQA-83933 | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -9880,7 +9880,6 @@ org.apache.catalina.tribes.level = FINE]]>
 						</if>
 
 						<delete dir="${test.app.server.liferay.home}/logs" />
-						<delete dir="${test.app.server.liferay.home}/work" />
 
 						<delete file="${test.app.server.liferay.home}/portal-setup-wizard.properties" />
 					</else>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRQA-83933

I used my method to measure the macro runtimes

Tested locally with the smoke test and on CI here: https://github.com/Kvale1733/liferay-portal/pull/439

These are my local findings: https://docs.google.com/spreadsheets/d/1uwIQKl4chhGbevDkP0cpKV6kU8SaV_otu9lfsVf9JYY/edit#gid=1361761583

And CI (Just using a few tests that run on a virtual instance as examples)
https://docs.google.com/spreadsheets/d/1ATdUS0p1Bkcmq2VzAUotQCDKv4-LQHuSLOU6tbu0ZOo/edit#gid=1151418895

I also tested the character set locally but that didn't make much of a difference. As you can see there is a significant speed increase in most macros when we keep the work folder. This will save time in tests that run in virtual instances since the first run will add some of the jsp's that will speed up the next test.

This will also speed up local testing if you use run-selenium-tomcat multiple times on the same bundle.

I couldn't find any regression on the CI run.

For context that cleanup was added here: https://github.com/liferay/liferay-portal/commit/42e555dd66b62d13df348797b51c57a8d19010f4

For https://liferay.atlassian.net/browse/LRQA-33833. It doesn't look like we run that test anymore. 

