### PR TITLE
LRQA-84051 | master

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1608,7 +1608,8 @@ app.server.type=@{app.server.type}]]></echo>
 		<attribute default="true" name="setup.proxy" />
 		<attribute default="true" name="setup.testable.jboss" />
 		<attribute default="true" name="setup.testable.tomcat" />
-		<attribute default="false" name="startup.testing" />
+		<attribute default="false" name="startup.testing.cold" />
+		<attribute default="false" name="startup.testing.warm" />
 		<attribute default="" name="test.build.fix.pack.zip.url" />
 		<attribute default="" name="test.fix.pack.base.url" />
 		<attribute default="" name="test.legacy.database.dump" />
@@ -1674,6 +1675,7 @@ app.server.type=@{app.server.type}]]></echo>
 										<ant antfile="build-test-${app.server.type}.xml" inheritAll="false" target="run-selenium-${app.server.type}">
 											<property name="app.server.start.executable.arg.line" value="${test.batch.app.server.start.executable.arg.line}" />
 											<property name="database.type" value="@{database.type}" />
+											<property name="startup.testing.warm" value="@{startup.testing.warm}" />
 											<property name="functional.test.type" value="@{functional.test.type}" />
 											<property name="liferay.portal.bundle" value="@{test.portal.bundle.version}" />
 											<property name="test.build.plugins.war.zip.url" value="@{test.plugins.war.zip.url}" />
@@ -1696,7 +1698,7 @@ app.server.type=@{app.server.type}]]></echo>
 										</if>
 
 										<if>
-											<equals arg1="@{startup.testing}" arg2="true" />
+											<equals arg1="@{startup.testing.cold}" arg2="true" />
 											<then>
 												<antcall inheritall="false" target="stop-app-server" />
 
@@ -5068,6 +5070,14 @@ information. Make sure to commit in all format-javadoc results.
 		<antcall target="functional-bundle-wildfly261-mysql57-jdk8" />
 	</target>
 
+	<target name="functional-smoke-cold-startup-tomcat90-hypersonic20-jdk8">
+		<run-functional-test app.server.type="tomcat" database.type="hypersonic" startup.testing.cold="true" test.portal.log.assert="true" />
+	</target>
+
+	<target name="functional-smoke-cold-startup-tomcat90-mysql57-jdk8">
+		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" startup.testing.cold="true" test.portal.log.assert="true" />
+	</target>
+
 	<target name="functional-smoke-jboss73-mysql57-jdk8">
 		<set-app-server-version-number app.server.type="jboss" app.server.version="7.3.0" />
 
@@ -5090,10 +5100,6 @@ information. Make sure to commit in all format-javadoc results.
 		<set-app-server-version-number app.server.type="jboss" app.server.version="7.4.0" />
 
 		<run-functional-test app.server.type="jboss" app.server.version="7.4.0" database.type="mysql" database.version="5.7" test.portal.log.assert="true" />
-	</target>
-
-	<target name="functional-smoke-startup-tomcat90-mysql57-jdk8">
-		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" startup.testing="true" test.portal.log.assert="true" />
 	</target>
 
 	<target name="functional-smoke-tcserver40-mysql57-jdk8">
@@ -5258,6 +5264,14 @@ information. Make sure to commit in all format-javadoc results.
 
 	<target name="functional-smoke-tomcat90-sybase160-jdk11_open">
 		<run-functional-test app.server.type="tomcat" database.type="sybase" test.portal.log.assert="true" />
+	</target>
+
+	<target name="functional-smoke-warm-startup-tomcat90-hypersonic20-jdk8">
+		<run-functional-test app.server.type="tomcat" database.type="hypersonic" startup.testing.warm="true" test.portal.log.assert="true" />
+	</target>
+
+	<target name="functional-smoke-warm-startup-tomcat90-mysql57-jdk8">
+		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" startup.testing.warm="true" test.portal.log.assert="true" />
 	</target>
 
 	<target name="functional-smoke-weblogic122-mysql57-jdk8">

--- a/build-test-tomcat.xml
+++ b/build-test-tomcat.xml
@@ -47,7 +47,9 @@
 	<target name="run-tomcat">
 		<lstopwatch action="start" name="run.tomcat" />
 
-		<antcall target="run-simple-server" />
+		<antcall target="run-simple-server">
+			<param name="cold.startup.testing" value="${cold.startup.testing}" />
+		</antcall>
 
 		<lstopwatch action="total" name="run.tomcat" />
 	</target>

--- a/build-test.xml
+++ b/build-test.xml
@@ -16264,6 +16264,15 @@ mail.send.blacklist=</echo>
 		<get-testcase-property property.name="skip.start.app.server" />
 
 		<if>
+			<equals arg1="${startup.testing.warm}" arg2="true" />
+			<then>
+				<antcall target="start-app-server-preserve-liferay-home" />
+
+				<antcall target="stop-app-server" />
+			</then>
+		</if>
+
+		<if>
 			<not>
 				<equals arg1="${skip.start.app.server}" arg2="true" />
 			</not>

--- a/test.properties
+++ b/test.properties
@@ -9304,12 +9304,46 @@
     test.batch.dist.app.servers[startup]=tomcat
 
     test.batch.names[startup]=\
-        functional-smoke-startup-tomcat90-mysql57-jdk8
+        functional-smoke-cold-startup-tomcat90-hypersonic20-jdk8,\
+        functional-smoke-cold-startup-tomcat90-mysql57-jdk8,\
+        functional-smoke-warm-startup-tomcat90-hypersonic20-jdk8,\
+        functional-smoke-warm-startup-tomcat90-mysql57-jdk8
 
-    test.batch.run.property.query[functional-smoke-startup-tomcat90-mysql57-jdk8][startup]=\
+    test.batch.run.property.query[functional-smoke-cold-startup-tomcat90-hypersonic20-jdk8][startup]=\
+        (testray.main.component.name == "Web Content Display")
+
+    test.batch.run.property.query[functional-smoke-cold-startup-tomcat90-mysql57-jdk8][startup]=\
         (\
             (testray.main.component.name  == "Web Content Administration") OR \
             (testray.main.component.name == "Web Content Display")\
+        )
+
+    test.batch.run.property.query[functional-smoke-warm-startup-tomcat90-hypersonic20-jdk8][startup]=\
+        (\
+            (app.server.types == null) OR \
+            (app.server.types ~ tomcat)\
+        ) AND \
+        (\
+            (database.types == null) OR \
+            (database.types ~ hypersonic)\
+        ) AND \
+        (\
+            (portal.smoke == false) OR \
+            (portal.smoke == true)\
+        )
+
+    test.batch.run.property.query[functional-smoke-cold-warm-tomcat90-mysql57-jdk8][startup]=\
+        (\
+            (app.server.types == null) OR \
+            (app.server.types ~ tomcat)\
+        ) AND \
+        (\
+            (database.types == null) OR \
+            (database.types ~ mysql)\
+        ) AND \
+        (\
+            (portal.smoke == false) OR \
+            (portal.smoke == true)\
         )
 
     #


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRQA-84051

So what we currently have is now functional-smoke-cold-startup-tomcat90-mysql57-jdk8. Which runs the test then restarts. Added that same scenario for hypsersonic (runs fewer web content tests than mysql)

The warm ones now restart and then run the test. That covers both hypersonic and mysql (runs smoke tests)
