### PR TITLE
LPD-X Add SYM_ENCRYPT database key proof of concept

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/DatabaseSecretKeyProtocolHook.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/DatabaseSecretKeyProtocolHook.java
@@ -1,0 +1,334 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal.jgroups;
+
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.security.Key;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import java.util.Base64;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jgroups.protocols.SYM_ENCRYPT;
+import org.jgroups.stack.Protocol;
+import org.jgroups.stack.ProtocolHook;
+
+/**
+ * Proof of concept. Resolves a shared AES key from the Liferay database and
+ * injects it into <code>SYM_ENCRYPT</code> before JGroups calls
+ * <code>init()</code>, so that no keystore is ever read and no operator
+ * configuration is required.
+ *
+ * <p>
+ * Wired through the JGroups <code>after_creation_hook</code> attribute on the
+ * <code>SYM_ENCRYPT</code> element. See
+ * <code>jgroups/secure/auto/udp_control.xml</code>.
+ * </p>
+ *
+ * <p>
+ * Deliberately uses <code>KeyGenerator</code> and <code>Base64</code> directly
+ * instead of Liferay's <code>Encryptor</code>, to keep the startup path free of
+ * OSGi service dependencies.
+ * </p>
+ *
+ * <p>
+ * Two system properties exist only to test rejection of a mismatched key:
+ * </p>
+ *
+ * <ul>
+ * <li>
+ * <code>sym.encrypt.poc.key.override</code>: a Base64 AES key to use instead of
+ * the database value, or the literal <code>random</code> to generate a throwaway
+ * key on every boot
+ * </li>
+ * </ul>
+ */
+public class DatabaseSecretKeyProtocolHook implements ProtocolHook {
+
+	@Override
+	public void afterCreation(Protocol protocol) throws Exception {
+		if (!(protocol instanceof SYM_ENCRYPT)) {
+			_log.info(
+				_PREFIX + "Ignoring non-SYM_ENCRYPT protocol " +
+					protocol.getName());
+
+			return;
+		}
+
+		SYM_ENCRYPT symEncrypt = (SYM_ENCRYPT)protocol;
+
+		_log.info(
+			_PREFIX + "afterCreation entered for " + symEncrypt.getName() +
+				"@" + System.identityHashCode(symEncrypt));
+
+		_log.info(
+			_PREFIX + "Pre-init state {secretKey=" + symEncrypt.secretKey() +
+				", symVersion=" + _toHex(symEncrypt.symVersion()) +
+					", symAlgorithm=" + symEncrypt.symAlgorithm() +
+						", symIvLength=" + symEncrypt.simIvLength() + "}");
+
+		_logCallStack();
+
+		SecretKey secretKey = _resolveSecretKey();
+
+		symEncrypt.setSecretKey(secretKey);
+
+		_log.info(
+			_PREFIX + "setSecretKey returned {secretKeyFingerprint=" +
+				_fingerprint(secretKey) + ", symAlgorithm=" +
+					symEncrypt.symAlgorithm() + ", symVersion=" +
+						_toHex(symEncrypt.symVersion()) + "}");
+
+		_startPostInitProbe(symEncrypt);
+	}
+
+	private String _fingerprint(Key key) {
+		byte[] encoded = key.getEncoded();
+
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < Math.min(4, encoded.length); i++) {
+			sb.append(String.format("%02x", encoded[i]));
+		}
+
+		sb.append("..(");
+		sb.append(encoded.length * 8);
+		sb.append(" bits)");
+
+		return sb.toString();
+	}
+
+	private SecretKey _generateSecretKey() throws Exception {
+		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+
+		keyGenerator.init(128);
+
+		return keyGenerator.generateKey();
+	}
+
+	private void _logCallStack() {
+		StackTraceElement[] stackTraceElements =
+			new Throwable().getStackTrace();
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(_PREFIX);
+		sb.append("Call stack at hook time:");
+
+		for (int i = 0; (i < stackTraceElements.length) && (i < 8); i++) {
+			sb.append("\n\tat ");
+			sb.append(stackTraceElements[i]);
+		}
+
+		_log.info(sb.toString());
+	}
+
+	private SecretKey _resolveSecretKey() throws Exception {
+		String override = System.getProperty(
+			"sym.encrypt.poc.key.override");
+
+		if (override != null) {
+			if (override.equals("random")) {
+				SecretKey secretKey = _generateSecretKey();
+
+				_log.info(
+					_PREFIX +
+						"OVERRIDE: generated a throwaway random key, ignoring " +
+							"the database {fingerprint=" +
+								_fingerprint(secretKey) + "}");
+
+				return secretKey;
+			}
+
+			SecretKey secretKey = new SecretKeySpec(
+				Base64.getDecoder().decode(override), "AES");
+
+			_log.info(
+				_PREFIX + "OVERRIDE: using the key from the system property, " +
+					"ignoring the database {fingerprint=" +
+						_fingerprint(secretKey) + "}");
+
+			return secretKey;
+		}
+
+		try (Connection connection = DataAccess.getConnection()) {
+			_log.info(
+				_PREFIX + "Opened JDBC connection {catalog=" +
+					connection.getCatalog() + ", schema=" +
+						connection.getSchema() + ", url=" +
+							connection.getMetaData().getURL() + "}");
+
+			DBInspector dbInspector = new DBInspector(connection);
+
+			if (!dbInspector.hasTable(_TABLE_NAME)) {
+				_log.info(_PREFIX + "Table " + _TABLE_NAME + " is absent");
+
+				_createTable(connection);
+			}
+			else {
+				_log.info(_PREFIX + "Table " + _TABLE_NAME + " already exists");
+			}
+
+			SecretKey secretKey = _selectSecretKey(connection);
+
+			if (secretKey != null) {
+				_log.info(
+					_PREFIX + "REUSED the key already stored in " +
+						_TABLE_NAME + " {keyId=" + _KEY_ID +
+							", fingerprint=" + _fingerprint(secretKey) + "}");
+
+				return secretKey;
+			}
+
+			secretKey = _generateSecretKey();
+
+			_log.info(
+				_PREFIX + "GENERATED a new AES key {keyId=" + _KEY_ID +
+					", fingerprint=" + _fingerprint(secretKey) + "}");
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"insert into " + _TABLE_NAME +
+							" (keyId, encodedKey) values (?, ?)")) {
+
+				preparedStatement.setString(1, _KEY_ID);
+				preparedStatement.setString(
+					2,
+					Base64.getEncoder().encodeToString(
+						secretKey.getEncoded()));
+
+				preparedStatement.executeUpdate();
+
+				_log.info(
+					_PREFIX + "INSERTED the generated key into " + _TABLE_NAME);
+
+				return secretKey;
+			}
+			catch (SQLException sqlException) {
+				_log.info(
+					_PREFIX + "Insert failed, assuming another node won the " +
+						"first boot race, reselecting {message=" +
+							sqlException.getMessage() + "}");
+
+				SecretKey winningSecretKey = _selectSecretKey(connection);
+
+				if (winningSecretKey == null) {
+					throw sqlException;
+				}
+
+				_log.info(
+					_PREFIX + "REUSED the key inserted by the winning node " +
+						"{fingerprint=" + _fingerprint(winningSecretKey) + "}");
+
+				return winningSecretKey;
+			}
+		}
+	}
+
+	private void _createTable(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement()) {
+			statement.executeUpdate(
+				"create table " + _TABLE_NAME +
+					" (keyId varchar(75) not null primary key, encodedKey " +
+						"varchar(255) not null)");
+
+			_log.info(_PREFIX + "Created table " + _TABLE_NAME);
+		}
+		catch (SQLException sqlException) {
+			_log.info(
+				_PREFIX + "Unable to create table " + _TABLE_NAME +
+					", assuming another node created it first {message=" +
+						sqlException.getMessage() + "}");
+		}
+	}
+
+	private SecretKey _selectSecretKey(Connection connection)
+		throws SQLException {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select encodedKey from " + _TABLE_NAME + " where keyId = ?")) {
+
+			preparedStatement.setString(1, _KEY_ID);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (!resultSet.next()) {
+					return null;
+				}
+
+				return new SecretKeySpec(
+					Base64.getDecoder().decode(resultSet.getString(1)), "AES");
+			}
+		}
+	}
+
+	private void _startPostInitProbe(SYM_ENCRYPT symEncrypt) {
+		Thread thread = new Thread(
+			() -> {
+				try {
+					Thread.sleep(20000);
+				}
+				catch (InterruptedException interruptedException) {
+					return;
+				}
+
+				_log.info(
+					_PREFIX + "POST-INIT probe for " + symEncrypt.getName() +
+						"@" + System.identityHashCode(symEncrypt) +
+							" {secretKeyFingerprint=" +
+								_fingerprint(symEncrypt.secretKey()) +
+									", symAlgorithm=" +
+										symEncrypt.symAlgorithm() +
+											", symIvLength=" +
+												symEncrypt.simIvLength() +
+													", symVersion=" +
+														_toHex(
+															symEncrypt.
+																symVersion()) +
+															"}");
+			},
+			"SYM_ENCRYPT PoC post-init probe");
+
+		thread.setDaemon(true);
+
+		thread.start();
+	}
+
+	private String _toHex(byte[] bytes) {
+		if (bytes == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		for (byte b : bytes) {
+			sb.append(String.format("%02x", b));
+		}
+
+		return sb.toString();
+	}
+
+	private static final String _KEY_ID = "cluster-link-default";
+
+	private static final String _PREFIX = "[SYM-DB-POC] ";
+
+	private static final String _TABLE_NAME = "ClusterSymEncryptKey";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DatabaseSecretKeyProtocolHook.class);
+
+}

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/auto/udp_control.xml
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/auto/udp_control.xml
@@ -1,0 +1,51 @@
+<config
+	xmlns="urn:org:jgroups"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd"
+>
+	<UDP
+		bind_addr="${cluster.link.bind.addr[&quot;cluster-link-control&quot;]}"
+		mcast_addr="${multicast.group.address[&quot;cluster-link-control&quot;]}"
+		mcast_port="${multicast.group.port[&quot;cluster-link-control&quot;]}"
+	/>
+	<PING />
+	<MERGE3
+		max_interval="30000"
+		min_interval="10000"
+	/>
+	<FD_SOCK />
+	<FD_ALL />
+	<VERIFY_SUSPECT timeout="1500" />
+	<SYM_ENCRYPT
+		after_creation_hook="com.liferay.portal.cluster.multiple.internal.jgroups.DatabaseSecretKeyProtocolHook"
+		sym_algorithm="AES/CBC/PKCS5Padding"
+		sym_iv_length="16"
+	/>
+	<pbcast.NAKACK2 xmit_interval="500"
+					xmit_table_num_rows="100"
+					xmit_table_msgs_per_row="2000"
+					xmit_table_max_compaction_time="30000"
+					use_mcast_xmit="false"
+					discard_delivered_msgs="true" />
+	<UNICAST3
+		conn_expiry_timeout="0"
+		xmit_interval="500"
+		xmit_table_max_compaction_time="60000"
+		xmit_table_msgs_per_row="2000"
+		xmit_table_num_rows="100"
+	/>
+	<pbcast.STABLE desired_avg_gossip="50000"
+				   max_bytes="4M"
+				   stability_delay="1000" />
+	<pbcast.GMS join_timeout="2000" print_local_addr="true" view_bundling="true" />
+	<UFC
+		max_credits="2M"
+		min_threshold="0.4"
+	/>
+	<MFC
+		max_credits="2M"
+		min_threshold="0.4"
+	/>
+	<FRAG2 frag_size="60K" />
+	<RSVP resend_interval="2000" timeout="10000" />
+</config>

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/auto/udp_transport.xml
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/auto/udp_transport.xml
@@ -1,0 +1,51 @@
+<config
+	xmlns="urn:org:jgroups"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd"
+>
+	<UDP
+		bind_addr="${cluster.link.bind.addr[&quot;cluster-link-udp&quot;]}"
+		mcast_addr="${multicast.group.address[&quot;cluster-link-udp&quot;]}"
+		mcast_port="${multicast.group.port[&quot;cluster-link-udp&quot;]}"
+	/>
+	<PING />
+	<MERGE3
+		max_interval="30000"
+		min_interval="10000"
+	/>
+	<FD_SOCK />
+	<FD_ALL />
+	<VERIFY_SUSPECT timeout="1500" />
+	<SYM_ENCRYPT
+		after_creation_hook="com.liferay.portal.cluster.multiple.internal.jgroups.DatabaseSecretKeyProtocolHook"
+		sym_algorithm="AES/CBC/PKCS5Padding"
+		sym_iv_length="16"
+	/>
+	<pbcast.NAKACK2 xmit_interval="500"
+					xmit_table_num_rows="100"
+					xmit_table_msgs_per_row="2000"
+					xmit_table_max_compaction_time="30000"
+					use_mcast_xmit="false"
+					discard_delivered_msgs="true" />
+	<UNICAST3
+		conn_expiry_timeout="0"
+		xmit_interval="500"
+		xmit_table_max_compaction_time="60000"
+		xmit_table_msgs_per_row="2000"
+		xmit_table_num_rows="100"
+	/>
+	<pbcast.STABLE desired_avg_gossip="50000"
+				   max_bytes="4M"
+				   stability_delay="1000" />
+	<pbcast.GMS join_timeout="2000" print_local_addr="true" view_bundling="true" />
+	<UFC
+		max_credits="2M"
+		min_threshold="0.4"
+	/>
+	<MFC
+		max_credits="2M"
+		min_threshold="0.4"
+	/>
+	<FRAG2 frag_size="60K" />
+	<RSVP resend_interval="2000" timeout="10000" />
+</config>


### PR DESCRIPTION
**Proof of concept only. Not intended to merge.**

## Problem

[LPD-81179](https://liferay.atlassian.net/browse/LPD-81179) upgrades JGroups from 4.1.7 to 5.5.x. JGroups 5.0 removed `MD5Token` and `SimpleToken`, and the default cluster link configuration depends on `MD5Token`:

```
cluster.link.channel.properties.control=jgroups/secure/md5/udp_control.xml
cluster.link.channel.properties.transport.0=jgroups/secure/md5/udp_transport.xml
```

Upstream removed those tokens because the token value can be recovered and replayed, so they never prevented rogue members from joining. The remaining AUTH implementations require generated keys and custom configuration files, so none can serve as a zero configuration default.

## Goal

Establish whether a `SYM_ENCRYPT` group key can be generated on first boot and shared through the Liferay database, giving every installation a unique cluster credential with no operator action and no keystore file.

## Proposed

`SYM_ENCRYPT` reads its key from a keystore only when no key has already been set:

```java
public void init() throws Exception {
    if (this.secret_key == null) {
        readSecretKeyFromKeystore();
    }
    super.init();
}
```

`ProtocolStack` invokes each protocol's after creation hook immediately before calling `init()` on it. That window is where this proof of concept injects the key, so the keystore path is never taken.

Three new files, no modifications to any existing file:

- `DatabaseSecretKeyProtocolHook` implements `org.jgroups.stack.ProtocolHook`. It resolves an AES 128 key over raw JDBC through `DataAccess`, self creates its table guarded by `DBInspector.hasTable`, and handles the first boot race by catching the insert failure and re-selecting.
- `jgroups/secure/auto/udp_control.xml` and `udp_transport.xml` replace `ASYM_ENCRYPT` with `SYM_ENCRYPT` in the same stack position, carry `after_creation_hook`, and delete the `AUTH` element entirely. Holding the key is the credential, so no AUTH token is required.

The mechanism is verified against the JGroups 4.1.7 jar that master already ships, so it carries no dependency on the 5.5 upgrade landing first. Removing the `AUTH` element is the only part of the change specific to 5.x.

## Verified By Running It

| Claim | Result |
| --- | --- |
| Node boots, channel forms, no keystore read, hook proven to run before `init()` | Pass |
| Key row created on first boot, reused on restart | Pass |
| Two peers sharing the database row form a view and exchange encrypted traffic | Pass, see caveat |
| A peer holding a different key is rejected | **Not tested** |

Hook logs `secretKey=null` and `symVersion=null` pre-init with a stack trace through `ProtocolStack.callAfterCreationHook`, and a post-init probe against the same protocol instance shows `sym_version` populated. Since `sym_version` is assigned only at the tail of `init()`, the ordering is unambiguous. The keystore attributes remain at JGroups' own defaults, confirming no keystore access was attempted.

## Known Limitations

1. The second peer in the two node test is a standalone JGroups process using the same jar, stack, and database row, not a second Liferay instance.
2. Rejection of a mismatched key is untested. This is the actual security property and remains unproven.
3. The key is stored as plaintext Base64. This is inherent to zero configuration, since the shared trust root has to be something every node already has, and it is a weaker posture than a permissioned keystore file.
4. `SYM_ENCRYPT` has no rotation mechanism. Rotating the key requires restarting every node simultaneously.
5. Concurrent `CREATE TABLE` across nodes booting into an empty database is untested. Existing precedent in the codebase guards row inserts, not DDL.
6. `AES/GCM/NoPadding` cannot be used. `Encrypt.initCipher` only constructs an `IvParameterSpec`, which providers reject in GCM mode, and the resulting failure is swallowed as a warning so messages are silently dropped. This ships as `AES/CBC/PKCS5Padding`.
7. Debug logging is deliberately verbose and the key generation bypasses the `Encryptor` service to keep an OSGi dependency out of the startup path. Both are proof of concept choices.

## Related

Closes nothing. Supports the default cluster authentication decision blocking [LPD-87977](https://liferay.atlassian.net/browse/LPD-87977). Original finding: [LPS-65857](https://liferay.atlassian.net/browse/LPS-65857).